### PR TITLE
eliminate coarse sweep using alphagrid

### DIFF
--- a/PyUoI/UoI_Lasso.py
+++ b/PyUoI/UoI_Lasso.py
@@ -2,20 +2,19 @@ import numpy as np
 
 from tqdm import trange
 
-import sklearn.linear_model as lm
-from sklearn.linear_model.base import (_preprocess_data, _rescale_data,
-                                       SparseCoefMixin)
+from sklearn.linear_model import LinearRegression, Lasso
+from sklearn.linear_model.base import (
+    LinearModel, _preprocess_data, SparseCoefMixin)
 from sklearn.linear_model.coordinate_descent import _alpha_grid
 from sklearn.metrics import r2_score
+from sklearn.model_selection import train_test_split
 from sklearn.utils import check_X_y
-from sklearn.utils.validation import check_random_state
 
 from PyUoI import utils
 
 
-class UoI_Lasso(lm.base.LinearModel, SparseCoefMixin):
+class UoI_Lasso(LinearModel, SparseCoefMixin):
     """The UoI-Lasso algorithm.
-
 
     See Bouchard et al., NIPS, 2017, for more details on UoI-Lasso and the
     Union of Intersections framework.
@@ -47,8 +46,14 @@ class UoI_Lasso(lm.base.LinearModel, SparseCoefMixin):
         to obtain validation scores. Small values of this parameters imply
         larger "perturbations" to the dataset.
 
-    stability_selection : float, or int, or 1-D array-like, default 1
-        Enfore
+    stability_selection : int, float, or array-like, default 1
+        If int, treated as the number of bootstraps that a feature must
+        appear in to guarantee placement in selection profile. If float,
+        must be between 0 and 1, and is instead the proportion of
+        bootstraps. If array-like, must consist of either ints or floats
+        between 0 and 1. In this case, each entry in the array-like object
+        will act as a separate threshold for placement in the selection
+        profile.
 
     copy_X : boolean, default True
         If True, X will be copied; else, it may be overwritten.
@@ -87,9 +92,9 @@ class UoI_Lasso(lm.base.LinearModel, SparseCoefMixin):
         self,
         n_boots_sel=48, n_boots_est=48,
         selection_frac=0.9, estimation_frac=0.9,
-        n_lambdas=48, stability_selection=1.,
-        estimation_score='BIC',
-        copy_X=True, fit_intercept=True, normalize=False, random_state=None
+        n_lambdas=48, stability_selection=1., eps=1e-3, warm_start=True,
+        estimation_score='r2',
+        copy_X=True, fit_intercept=True, normalize=True, random_state=None
     ):
         # data split fractions
         self.selection_frac = selection_frac
@@ -100,7 +105,9 @@ class UoI_Lasso(lm.base.LinearModel, SparseCoefMixin):
         # other hyperparameters
         self.n_lambdas = n_lambdas
         self.stability_selection = stability_selection
+        self.eps = eps
         self.estimation_score = estimation_score
+        self.warm_start = warm_start
         # preprocessing
         self.copy_X = copy_X
         self.fit_intercept = fit_intercept
@@ -108,37 +115,35 @@ class UoI_Lasso(lm.base.LinearModel, SparseCoefMixin):
         self.random_state = random_state
 
     def fit(
-        self, X, y, groups=None, verbose=False, sample_weight=None,
-        option=True
+        self, X, y, stratify=None, verbose=False
     ):
         """Fit data according to the UoI-Lasso algorithm.
-        Relevant information (fits, residuals, model performance) is stored
-        within object. Thus, nothing is returned by this function.
 
         Parameters
         ----------
-        X : np array (2d)
-            the design matrix, containing the predictors.
-            its shape is assumed to be (number of samples, number of features).
+        X : ndarray or scipy.sparse matrix, (n_samples, n_features)
+            The design matrix.
 
-        y : np array (1d)
-            the vector of dependent variables.
-            its length is assumed to be (number of samples,).
+        y : ndarray, shape (n_samples,)
+            Response vector. Will be cast to X's dtype if necessary.
+            Currently, this implementation does not handle multiple response
+            variables.
 
-        seed : int
-            a seed for the random number generator. this number is relevant
-            for the choosing bootstraps and dividing the data into training and
-            test sets.
+        stratify : array-like or None, default None
+            Ensures groups of samples are alloted to training/test sets
+            proportionally. Labels for each group must be an int greater
+            than zero. Must be of size equal to the number of samples, with
+            further restrictions on the number of groups.
 
         verbose : boolean
-            a boolean switch indicating whether the fitting should print out
-            its progress.
+            A switch indicating whether the fitting should print out messages
+            displaying progress. Utilizes tqdm to indicate progress on
+            bootstraps.
         """
 
         # perform checks
         X, y = check_X_y(X, y, accept_sparse=['csr', 'csc', 'coo'],
                          y_numeric=True, multi_output=True)
-        rng = check_random_state(self.random_state)
 
         # preprocess data
         X, y, X_offset, y_offset, X_scale = _preprocess_data(
@@ -146,140 +151,123 @@ class UoI_Lasso(lm.base.LinearModel, SparseCoefMixin):
             copy=self.copy_X
         )
 
-        if sample_weight is not None and np.atleast_1d(sample_weight).ndim > 1:
-            raise ValueError("Sample weights must be 1D array or scalar")
-
-        if sample_weight is not None:
-            # Sample weight can be implemented via a simple rescaling.
-            X, y = _rescale_data(X, y, sample_weight)
-
         # extract model dimensions
         self.n_samples, self.n_features = X.shape
-
-        # group leveling
-        if groups is None:
-            self.groups_ = np.ones(self.n_samples_)
-        else:
-            self.groups_ = np.array(groups)
 
         ####################
         # Selection Module #
         ####################
-        if verbose:
-            print('(1) Loaded data.\n %s samples with %s features.'
-                  % (self.n_samples, self.n_features))
-
+        # choose the lamba parameters for selection sweep
         self.lambdas = _alpha_grid(
             X=X, y=y,
             l1_ratio=1.0,
             fit_intercept=self.fit_intercept,
-            eps=1e-3,
+            eps=self.eps,
             n_alphas=self.n_lambdas,
             normalize=self.normalize
         )
 
-        # sweep over the grid of regularization strengths
-        estimates_selection, _ = \
-            self.lasso_sweep(
-                X, y, self.lambdas, self.train_frac_sel, self.n_boots_sel,
-                desc='fine lasso sweep', verbose=verbose
+        # initialize selection
+        selection_coefs = np.zeros(
+            (self.n_boots_sel, self.n_lambdas, self.n_features),
+            dtype=np.float32
+        )
+
+        # iterate over bootstraps
+        for bootstrap in trange(
+            self.n_boots_sel, desc='Model Selection', disable=not verbose
+        ):
+            # draw a resampled bootstrap
+            X_train, X_test, y_train, y_test = train_test_split(
+                X, y,
+                train_size=self.selection_frac,
+                stratify=stratify,
+                random_state=self.random_state
+            )
+
+            # perform a sweep over the regularization strengths
+            selection_coefs[bootstrap, :, :] = self.lasso_sweep(
+                X=X, y=y,
+                lambdas=self.lambdas,
+                warm_start=self.warm_start,
+                random_state=self.random_state
             )
 
         # perform the intersection step
-        self.intersection(estimates_selection)
+        self.intersection(selection_coefs)
 
         #####################
         # Estimation Module #
         #####################
-        # we'll use the supports obtained in the selection module to calculate
-        # bagged OLS estimates over bootstraps
-
-        if verbose:
-            print('(3) Beginning model estimation, with %s bootstraps.'
-                  % self.n_boots_est)
-
         # set up data arrays
         estimates = np.zeros(
-            (self.n_boots_est, self.n_lambdas, self.n_features_),
+            (
+                self.n_boots_est,
+                self.n_selection_thresholds * self.n_lambdas,
+                self.n_features
+            ),
             dtype=np.float32
         )
-        scores = np.zeros((self.n_boots_est, self.n_lambdas), dtype=np.float32)
+        self.scores = np.zeros(
+            (
+                self.n_boots_est,
+                self.n_selection_thresholds * self.n_lambdas
+            ),
+            dtype=np.float32
+        )
 
         # iterate over bootstrap samples
         for bootstrap in trange(
             self.n_boots_est, desc='Model Estimation', disable=not verbose
         ):
 
-            # extract the bootstrap indices, keeping a fraction of the data
-            # available for testing
-            train_idx, test_idx = utils.leveled_randomized_ids(
-                self.groups_, self.train_frac_est
+            # draw a resampled bootstrap
+            X_train, X_test, y_train, y_test = train_test_split(
+                X, y,
+                train_size=self.selection_frac,
+                stratify=stratify,
+                random_state=self.random_state
             )
 
             # iterate over the regularization parameters
             for lamb_idx, lamb in enumerate(self.lambdas):
                 # extract current support set
-                support = self.supports_[lamb_idx]
-
-                # extract response vectors
-                y_train = y[train_idx]
-                y_test = y[test_idx]
-
+                support = self.supports[lamb_idx]
                 # if nothing was selected, we won't bother running OLS
                 if np.any(support):
-                    # get design matrices
-                    X_train = X[train_idx][:, support]
-                    X_test = X[test_idx][:, support]
-
                     # compute ols estimate
-                    ols = lm.LinearRegression()
-                    ols.fit(X_train, y_train)
+                    ols = LinearRegression()
+                    ols.fit(
+                        X_train[:, support],
+                        y_train
+                    )
 
                     # store the fitted coefficients
-                    estimates[bootstrap, lamb_idx, support] = ols.coef_
+                    estimates[bootstrap, lamb_idx, support] = ols.coef_.ravel()
 
                     # obtain predictions for scoring
-                    y_pred = ols.predict(X_test)
+                    y_pred = ols.predict(X_test[:, support])
                 else:
                     # no prediction since nothing was selected
                     y_pred = np.zeros(y_test.size)
 
-                # calculate estimation score
-                if self.estimation_score == 'r2':
-                    scores[bootstrap, lamb_idx] = r2_score(
-                        y_true=y_test,
-                        y_pred=y_pred
-                    )
-                elif self.estimation_score == 'BIC':
-                    y_pred = ols.predict(X_test)
-                    n_features = np.count_nonzero(support)
-                    scores[bootstrap, lamb_idx] = -utils.BIC(
-                        y_true=y_test,
-                        y_pred=y_pred,
-                        n_features=n_features
-                    )
-                elif self.estimation_score == 'AIC':
-                    y_pred = ols.predict(X_test)
-                    n_features = np.count_nonzero(support)
-                    scores[bootstrap, lamb_idx] = -utils.AIC(
-                        y_true=y_test,
-                        y_pred=y_pred,
-                        n_features=n_features
-                    )
-                elif self.estimation_score == 'AICc':
-                    y_pred = ols.predict(X_test)
-                    n_features = np.count_nonzero(support)
-                    scores[bootstrap, lamb_idx] = -utils.AICc(
-                        y_true=y_test,
-                        y_pred=y_pred,
-                        n_features=n_features
-                    )
-                else:
-                    raise ValueError(
-                        str(self.estimation_score) + ' is not a valid option.'
-                    )
+                # only negate if we're using an information criterion
+                negate = (
+                    self.estimation_score == 'BIC' or
+                    self.estimation_score == 'AIC' or
+                    self.estimation_score == 'AICc'
+                )
 
-        self.lambda_max_idx = np.argmax(scores, axis=1)
+                # calculate estimation score
+                self.scores[bootstrap, lamb_idx] = self.score_predictions(
+                    y_true=y_test,
+                    y_pred=y_pred,
+                    n_features=np.count_nonzero(support),
+                    metric=self.estimation_score,
+                    negate=negate
+                )
+
+        self.lambda_max_idx = np.argmax(self.scores, axis=1)
         # extract the estimates over bootstraps from model with best lambda
         best_estimates = estimates[
             np.arange(self.n_boots_est), self.lambda_max_idx, :
@@ -287,138 +275,249 @@ class UoI_Lasso(lm.base.LinearModel, SparseCoefMixin):
         # take the median across estimates for the final, bagged estimate
         self.coef_ = np.median(best_estimates, axis=0)
 
-        if verbose:
-            print("UoI Lasso complete.")
-
         self._set_intercept(X_offset, y_offset, X_scale)
 
         return self
 
-    def intersection(self, estimates):
+    def stability_selection_to_threshold(self, stability_selection):
+        """Converts user inputted stability selection to an array of
+        thresholds. These thresholds correspond to the number of bootstraps
+        that a feature must appear in to guarantee placement in the selection
+        profile.
+
+        Parameters
+        ----------
+        stability_selection : int, float, or array-like
+            If int, treated as the number of bootstraps that a feature must
+            appear in to guarantee placement in selection profile. If float,
+            must be between 0 and 1, and is instead the proportion of
+            bootstraps. If array-like, must consist of either ints or floats
+            between 0 and 1. In this case, each entry in the array-like object
+            will act as a separate threshold for placement in the selection
+            profile.
+        """
+
+        # single float, indicating proportion of bootstraps
+        if isinstance(self.stability_selection, float):
+            selection_thresholds = np.array([int(
+                stability_selection * self.n_boots_sel
+            )])
+
+        # single int, indicating number of bootstraps
+        elif isinstance(stability_selection, int):
+            selection_thresholds = np.array([int(
+                stability_selection
+            )])
+
+        # list, to be converted into numpy array
+        elif isinstance(stability_selection, list):
+            # list of floats
+            if all(isinstance(idx, float) for idx in stability_selection):
+                selection_thresholds = \
+                    self.n_boots_sel * np.array(stability_selection)
+
+            # list of ints
+            elif all(isinstance(idx, int) for idx in stability_selection):
+                selection_thresholds = np.array(stability_selection)
+
+            else:
+                raise ValueError("Stability selection list must consist of "
+                                 "floats or ints.")
+
+        # numpy array
+        elif isinstance(stability_selection, np.ndarray):
+            # np array of floats
+            if np.issubdtype(stability_selection.dtype.type, np.floating):
+                selection_thresholds = self.n_boots_sel * stability_selection
+
+            # np array of ints
+            elif np.issubdtype(stability_selection.dtype.type, np.integer):
+                selection_thresholds = stability_selection
+
+            else:
+                raise ValueError("Stability selection array must consist of "
+                                 "floats or ints.")
+
+        else:
+            raise ValueError("Stability selection must be a valid float, int "
+                             "or array.")
+
+        # ensure that ensuing list of selection thresholds satisfies
+        # the correct bounds
+        if not (
+            np.all(selection_thresholds <= self.n_boots_sel) and
+            np.all(selection_thresholds > 1)
+        ):
+            raise ValueError("Stability selection thresholds must be within "
+                             "the correct bounds.")
+
+        return selection_thresholds
+
+    def intersection(self, coefs):
+        """Performs the intersection operation on selection coefficients
+        using stability selection criteria.
+
+        Parameters
+        ----------
+        coefs : np.ndarray, shape (# bootstraps, # lambdas, # features)
+            The coefficients obtain from the selection sweep, corresponding to
+            each bootstrap and choice of L1 regularization strength.
+        """
+
+        # extract selection thresholds from user provided stability selection
+        self.selection_thresholds = self.stability_selection_to_threshold(
+            stability_selection=self.stability_selection
+        )
+
         # create support matrix
-        self.supports_ = np.zeros(
-            (self.n_selection_thres, self.n_lambdas, self.n_features_),
+        self.n_selection_thresholds = self.selection_thresholds.size
+        self.supports = np.zeros(
+            (self.n_selection_thresholds, self.n_lambdas, self.n_features),
             dtype=bool
         )
 
-        # choose selection fraction threshold values to use
-        selection_frac_thresholds = np.linspace(
-            self.selection_thres_min,
-            self.selection_thres_max,
-            self.n_selection_thres
-        )
-        # calculate the actual number of thresholds, but delete any repetitions
-        selection_thresholds = np.sort(np.unique(
-            (self.n_boots_sel * selection_frac_thresholds).astype('int'))
-        )
-
         # iterate over each stability selection threshold
-        for thres_idx, threshold in enumerate(selection_thresholds):
+        for thresh_idx, threshold in enumerate(self.selection_thresholds):
             # calculate the support given the specific selection threshold
-            self.supports_[thres_idx, :] = \
-                np.count_nonzero(estimates, axis=0) >= threshold
+            self.supports[thresh_idx, ...] = \
+                np.count_nonzero(coefs, axis=0) >= threshold
 
-        self.supports_ = np.reshape(
-            self.supports_,
-            (self.n_selection_thres * self.n_lambdas, self.n_features_)
-        )
+        # unravel the dimension corresponding to selection thresholds
+        self.supports = np.squeeze(np.reshape(
+            self.supports,
+            (self.n_selection_thresholds * self.n_lambdas, self.n_features)
+        ))
 
-        return self.supports_
+        return
 
-    def score(self, X, y, metric='r2'):
-        # make predictions
-        if self.fit_intercept:
-            y_hat = np.dot(X, self.coef_) + self.intercept_
-        else:
-            y_hat = np.dot(X, self.coef_)
+    def score_predictions(
+        self, y_true, y_pred, metric='r2', negate=False, **kwargs
+    ):
+        """Score, according to some metric, predictions provided by a model.
+
+        Parameters
+        ----------
+        y_true : array-like
+            The true response variables.
+
+        y_pred : array-like
+            The predicted response variables.
+
+        metric : string
+            The type of score to run on the prediction. Valid options include
+            'r2' (explained variance), 'BIC' (Bayesian information criterion),
+            'AIC' (Akaike information criterion), and 'AICc' (corrected AIC).
+
+        negate : bool
+            Whether to negate the score. Useful in cases like AIC and BIC,
+            where minimum score is preferable.
+
+        Returns
+        -------
+        score : float
+            The score.
+        """
 
         if metric == 'r2':
-            return r2_score(y, y_hat)
-        elif metric == 'BIC':
-            if self.fit_intercept:
-                n_features = np.count_nonzero(self.coef_) + 1
-            else:
-                n_features = np.count_nonzero(self.coef_)
-
-            rss = np.sum((y - y_hat)**2)
-            return utils.BIC(
-                n_features=n_features,
-                n_samples=y.shape[0],
-                rss=rss
+            score = r2_score(
+                y_true=y_true,
+                y_pred=y_pred
+            )
+        elif self.estimation_score == 'BIC':
+            score = utils.BIC(
+                y_true=y_true,
+                y_pred=y_pred,
+                n_features=kwargs.get('n_features')
+            )
+        elif self.estimation_score == 'AIC':
+            score = utils.AIC(
+                y_true=y_true,
+                y_pred=y_pred,
+                n_features=kwargs.get('n_features')
+            )
+        elif self.estimation_score == 'AICc':
+            score = utils.AICc(
+                y_true=y_true,
+                y_pred=y_pred,
+                n_features=kwargs.get('n_features')
             )
         else:
-            raise ValueError('Incorrect metric specified.')
+            raise ValueError(
+                metric + ' is not a valid option.'
+            )
 
+        # negate score
+        if negate:
+            score = -score
+
+        return score
+
+    @staticmethod
     def lasso_sweep(
-        self, X, y, lambdas, train_frac, n_bootstraps, desc='', verbose=False
+        X, y, lambdas, normalize=True, max_iter=10000, warm_start=True,
+        random_state=None
     ):
-        """Perform Lasso regression across bootstraps of a dataset for a sweep
+        """Perform Lasso regression on a dataset over a sweep
         of L1 penalty values.
 
         Parameters
         ----------
-        X : np.array
-            data array containing regressors; assumed to be 2-d array with
-            shape n_samples x n_features
+        X : ndarray or scipy.sparse matrix, (n_samples, n_features)
+            The design matrix.
 
-        y : np.array
-            data array containing dependent variable; assumed to be a 1-d array
-            with length n_samples
+        y : ndarray, shape (n_samples,)
+            Response vector.
 
-        lambdas : np.array
-            the set of regularization parameters to run boostraps over
+        lambdas : ndarray, shape (n_lambdas)
+            The set of regularization parameters over which to run lasso fits.
 
-        train_frac : float
-            float between 0 and 1; the fraction of data to use for training
+        normalize : boolean, default False
+            If True, the regressors X will be normalized before regression by
+            subtracting the mean and dividing by the l2-norm.
 
-        n_bootstraps : int
-            the number of bootstraps to obtain from the dataset; each bootstrap
-            will undergo a Lasso regression
+        max_iter : int, default 10000
+            The maximum number of iterations.
+
+        warm_start : bool, optional
+            When set to True, reuse the solution of the previous call to fit as
+            initialization, otherwise, just erase the previous solution.
+
+        random_state : int, RandomState instance or None, default None
+            The seed of the pseudo random number generator that selects a
+            random feature to update.  If int, random_state is the seed used by
+            the random number generator; If RandomState instance, random_state
+            is the random number generator; If None, the random number
+            generator is the RandomState instance used by `np.random`.
 
         Returns
         -------
-        estimates : np.array
-            predicted regressors for each bootstrap and lambda value; shape is
-            (n_bootstraps, n_lambdas, n_features)
-
-        scores : np.array
-            scores by the model for each bootstrap and lambda
-            value; shape is (n_bootstraps, n_lambdas)
+        coefs : nd.array, shape (n_lambdas, n_features)
+            Predicted parameter values for each regularization strength.
         """
 
         n_lambdas = len(lambdas)
-        n_samples, n_features = X.shape
-        # create arrays to collect results
-        estimates = np.zeros(
-            (n_bootstraps, n_lambdas, n_features),
+        n_features = X.shape[1]
+
+        coefs = np.zeros(
+            (n_lambdas, n_features),
             dtype=np.float32
         )
-        scores = np.zeros((n_bootstraps, n_lambdas), dtype=np.float32)
+
+        # initialize lasso fit object
+        lasso = Lasso(
+            normalize=normalize,
+            max_iter=max_iter,
+            warm_start=warm_start,
+            random_state=random_state
+        )
+
         # apply the Lasso to bootstrapped datasets
-        for bootstrap in trange(n_bootstraps, desc=desc, disable=not verbose):
-            # for each bootstrap, we'll split the data into a randomly assigned
-            # training and test set
-            train, test = utils.leveled_randomized_ids(
-                self.groups_,
-                train_frac
-            )
-            # iterate over the provided L1 penalty values
-            for lamb_idx, lamb in enumerate(lambdas):
-                # run the Lasso on the training set
-                lasso = lm.Lasso(
-                    alpha=lamb,
-                    max_iter=10000,
-                    fit_intercept=self.fit_intercept
-                )
-                lasso.fit(
-                    X[train], y[train] - y[train].mean()
-                )
-                estimates[bootstrap, lamb_idx, :] = lasso.coef_
+        for lamb_idx, lamb in enumerate(lambdas):
+            # reset the regularization parameter
+            lasso.set_params(alpha=lamb)
+            # rerun fit
+            lasso.fit(X, y)
+            # store coefficients
+            coefs[lamb_idx, :] = lasso.coef_
 
-                # run trained Lasso on the test set and obtain predictions
-                y_hat = X[test].dot(estimates[bootstrap, lamb_idx, :])
-                y_true = y[test] - y[test].mean()
-                # calculate the explained variance using the predicted values
-                scores[bootstrap, lamb_idx] = r2_score(y_true, y_hat)
-
-        return estimates, scores
+        return coefs

--- a/PyUoI/utils.py
+++ b/PyUoI/utils.py
@@ -1,203 +1,159 @@
-import pdb, time
 import numpy as np
 import scipy.sparse as sparse
-from scipy.sparse.linalg import spsolve
 from numpy.linalg import norm, cholesky
 
-def BIC(n_features, n_samples, rss):
-	"""Calculate the Bayesian Information Criterion under the assumption of 
-	normally distributed disturbances (which allows the BIC to take on the
-	simple form below).
-	
-	Parameters
-	----------
-	n_features : int
-		number of model features
 
-	n_samples : int
-		number of samples in the dataset
+def BIC(y_true, y_pred, n_features):
+    """Calculate the Bayesian Information Criterion under the assumption of
+    normally distributed disturbances.
 
-	rss : float
-		the residual sum of squares
+    Parameters
+    ----------
+    y_true : np.ndarray
+        Array of true response values.
 
-	Returns
-	-------
-	BIC : float
-		Bayesian Information Criterion
-	"""
-	BIC = n_samples * np.log(rss/n_samples) + n_features * np.log(n_samples)
-	return BIC
+    y_pred : np.ndarray
+        Array of predicted response values.
+
+    n_features : int
+        Number of features used in the model.
+
+    Returns
+    -------
+    BIC : float
+        Bayesian Information Criterion
+    """
+
+    n_samples = y_true.size
+    # calculate residual sum of squares
+    rss = np.sum((y_true - y_pred)**2)
+
+    BIC = n_samples * np.log(rss / n_samples) + \
+        n_features * np.log(n_samples)
+    return BIC
+
 
 def AIC(y_true, y_pred, n_features):
-	n_samples = y_true.size
-	rss = np.sum((y_true - y_pred)**2)
-	AIC = n_samples * np.log(rss/n_samples) + n_features * 2
-	return AIC
+    """Calculate the Akaike Information Criterion under the assumption of
+    normally distributed disturbances. Utilizes a softer penalty on the
+    model parsimony than the BIC.
+
+    Parameters
+    ----------
+    y_true : np.ndarray
+        Array of true response values.
+
+    y_pred : np.ndarray
+        Array of predicted response values.
+
+    n_features : int
+        Number of features used in the model.
+
+    Returns
+    -------
+    AIC : float
+        Akaike Information Criterion
+    """
+
+    n_samples = y_true.size
+    # calculate residual sum of squares
+    rss = np.sum((y_true - y_pred)**2)
+
+    AIC = n_samples * np.log(rss / n_samples) + \
+        n_features * 2
+    return AIC
+
 
 def AICc(y_true, y_pred, n_features):
-	n_samples = y_true.size
-	rss = np.sum((y_true - y_pred)**2)
-	AICc = n_samples * np.log(rss/n_samples) + n_features * 2 \
-		+ 2 * (n_features**2 + n_features)/(n_samples - n_features - 1)
-	return AICc
+    """Calculate the corrected Akaike Information Criterion under the
+    assumption of normally distributed disturbances. Modifies the parsimony
+    penalty. Useful in cases when the number of samples is small.
 
-def leveled_randomized_ids(groups, fraction):
-	"""Grab bootstrap indices that are leveled across groups.
+    Parameters
+    ----------
+    y_true : np.ndarray
+        Array of true response values.
 
-	Parameters
-	----------
-	groups : array of size (n_samples)
-		contains indices identifying each sample to a specific group
+    y_pred : np.ndarray
+        Array of predicted response values.
 
-	fraction : float
-		fraction of samples to be selected
+    n_features : int
+        Number of features used in the model.
 
-	Returns
-	-------
-	leveled_ids : array of size (n_selected_samples)
-		contains the leveled indices that are selected into the bootstrap
+    Returns
+    -------
+    AICc : float
+        corrected Akaike Information Criterion
+    """
 
-	leftover_ids : array
-		contains the leftover indices (useful for splitting into train/test sets)
+    n_samples = y_true.size
+    # calculate residual sum of squares
+    rss = np.sum((y_true - y_pred)**2)
+    AICc = n_samples * np.log(rss / n_samples) + \
+        n_features * 2 + \
+        2 * (n_features**2 + n_features) / (n_samples - n_features - 1)
+    return AICc
 
-	"""
-	# initialize id arrays
-	leveled_ids = np.array([])
-	leftover_ids = np.array([])
-	# extract unique group ids
-	unique_ids = np.unique(groups)
-	# iterate through the unique group ids
-	for group_id in unique_ids:
-		# extract the sample indices in the current group
-		candidate_idx = np.argwhere(groups == group_id).ravel()
-		# number of samples that'll be selected from this group into bootstrap
-		n_ids_group = int(fraction * candidate_idx.size)
-		# permute the ids
-		permuted = np.random.permutation(candidate_idx)
-		# split up the ids into the selected and leftover arrays
-		selected_ids_group, leftover_ids_group = np.split(permuted, [n_ids_group])
-		# toss the selected/leftover ids in their corresponding group
-		leveled_ids = np.append(leveled_ids, selected_ids_group)
-		leftover_ids = np.append(leftover_ids, leftover_ids_group)
-	return leveled_ids.astype('int'), leftover_ids.astype('int')
 
-def lasso_admm(X, y, lamb, rho=1., alpha=1., 
-			max_iter=1000, abs_tol=1e-5, rel_tol=1e-3,
-			verbose=False):
-	"""Solve the Lasso optimization problem using Alternating Direction Method of Multipliers (ADMM)
-	
-	Convergence criteria are given in section 3.3.1 in the Boyd manuscript (equation 3.12).
-	"""
-	n_samples, n_features = X.shape
+def lasso_admm(
+    X, y, lamb, rho=1., alpha=1.,
+    max_iter=1000, abs_tol=1e-5, rel_tol=1e-3,
+    verbose=False
+):
+    """Solve the Lasso optimization problem using Alternating Direction Method
+    of Multipliers (ADMM) Convergence criteria are given in section 3.3.1 in
+    the Boyd manuscript (equation 3.12).
+    """
+    n_samples, n_features = X.shape
 
-	# initialize parameter estimates x/z and dual estimates u (equivalent to y)
-	x = np.zeros((n_features, 1))
-	z = np.zeros((n_features, 1))
-	# dual; equivalent to y in most formulations
-	u = np.zeros((n_features, 1))
+    # initialize parameter estimates x/z and dual estimates u (equivalent to y)
+    x = np.zeros((n_features, 1))
+    z = np.zeros((n_features, 1))
+    # dual; equivalent to y in most formulations
+    u = np.zeros((n_features, 1))
 
-	Xy = np.dot(X.T, y).reshape((n_features, 1))
-	inv = np.linalg.inv(np.dot(X.T, X) + rho * np.identity(n_features))
+    Xy = np.dot(X.T, y).reshape((n_features, 1))
+    inv = np.linalg.inv(np.dot(X.T, X) + rho * np.identity(n_features))
 
-	for iteration in range(max_iter):
-		# update x estimates
-		x = np.dot(inv, Xy + rho * (z - u))
+    for iteration in range(max_iter):
+        # update x estimates
+        x = np.dot(inv, Xy + rho * (z - u))
 
-		# handle the over-relaxation term
-		z_old = np.copy(z)
-		x_hat = alpha * x + (1 - alpha) * z_old
-		
-		# update z term with over-relaxation
-		z = shrinkage(x=x_hat, threshold=lamb/rho)
+        # handle the over-relaxation term
+        z_old = np.copy(z)
+        x_hat = alpha * x + (1 - alpha) * z_old
 
-		# update dual
-		u += x_hat - z
+        # update z term with over-relaxation
+        z = shrinkage(x=x_hat, threshold=lamb / rho)
 
-		# check convergence using eqn 3.12
-		r_norm = norm(x - z)
-		s_norm = norm(rho * (z - z_old))
+        # update dual
+        u += x_hat - z
 
-		eps_primal = np.sqrt(n_features) * abs_tol + np.maximum(norm(x), norm(z)) * rel_tol
-		eps_dual = np.sqrt(n_features) * abs_tol + norm(u) * rel_tol
+        # check convergence using eqn 3.12
+        r_norm = norm(x - z)
+        s_norm = norm(rho * (z - z_old))
 
-		if (r_norm <= eps_primal) and (s_norm <= eps_dual):
-			if verbose: print('Convergence: iteration %s' %iteration)
-			break
-	return z.ravel()
+        eps_primal = np.sqrt(n_features) * abs_tol + \
+            np.maximum(norm(x), norm(z)) * rel_tol
+        eps_dual = np.sqrt(n_features) * abs_tol + norm(u) * rel_tol
 
-def lasso_admm_old(X, y, alpha, rho=1., rel_par=1., max_iter=50, ABSTOL=1e-3, RELTOL=1e-2):
-	"""
-	 Solve lasso problem via ADMM
-	
-	 [z, history] = lasso_admm(X,y,alpha,rho,rel_par)
-	
-	 Solves the following problem via ADMM:
-	
-		 minimize 1/2*|| Ax - y ||_2^2 + alpha || x ||_1
-	
-	 The solution is returned in the vector z.
-	
-	 history is a dictionary containing the objective value, the primal and
-	 dual residual norms, and the tolerances for the primal and dual residual
-	 norms at each iteration.
-	
-	 rho is the augmented Lagrangian parameter.
-	
-	 rel_par is the over-relaxation parameter (typical values for rel_par are
-	 between 1.0 and 1.8).
-	
-	 More information can be found in the paper linked at:
-	 http://www.stanford.edu/~boyd/papers/distr_opt_stat_learning_admm.html
-	"""
-	# Data preprocessing
-	n_samples, n_features = X.shape
-	# save a matrix-vector multiply
-	Xy = np.dot(X.T, y).reshape((n_features, 1))
+        if (r_norm <= eps_primal) and (s_norm <= eps_dual):
+            if verbose:
+                print('Convergence: iteration %s' % iteration)
+            break
+    return z.ravel()
 
-	# ADMM solver
-	x = np.zeros((n_features, 1))
-	z = np.zeros((n_features, 1))
-	u = np.zeros((n_features, 1))
-
-	# cache the (Cholesky) factorization
-	L, U = factor(X, rho)
-
-	for k in range(max_iter):
-		# x-update 
-		q = Xy + rho * (z - u)  # (temporary value)
-		if n_samples >= n_features:
-			x = spsolve(U, spsolve(L, q)).reshape((n_features, 1))
-		else:
-			ULXq = spsolve(U, spsolve(L, X.dot(q)))
-			x = (q * 1. / rho) - ((np.dot(X.T, ULXq)) * 1. / (rho ** 2))
-		# z-update with relaxation
-		zold = np.copy(z)
-		x_hat = rel_par * x + (1. - rel_par) * zold
-		z = shrinkage(x_hat + u, alpha * 1. / rho)
-		# u-update
-		u += (x_hat - z)
-
-		# diagnostics, reporting, termination checks
-		#objval = objective(X, y, alpha, x, z)
-		r_norm = norm(x - z)
-		s_norm = norm(-rho * (z - zold))
-		eps_pri = np.sqrt(n_features) * ABSTOL + RELTOL * np.maximum(norm(x), norm(-z))
-		eps_dual = np.sqrt(n_features) * ABSTOL + RELTOL * norm(rho * u)
-
-		if (r_norm < eps_pri) and (s_norm < eps_dual):
-			break
-
-	return z.ravel()
 
 def shrinkage(x, threshold):
-	return np.maximum(0., x - threshold) - np.maximum(0., -x - threshold)
+    return np.maximum(0., x - threshold) - np.maximum(0., -x - threshold)
+
 
 def factor(X, rho):
-	n_samples, n_features = X.shape
-	if n_samples >= n_features:
-			L = cholesky(np.dot(X.T, X) + rho * sparse.eye(n_features))
-	else:
-			L = cholesky(sparse.eye(n_samples) + 1. / rho * (np.dot(X, X.T)))
-	L = sparse.csc_matrix(L)
-	U = sparse.csc_matrix(L.T)
-	return L, U
+    n_samples, n_features = X.shape
+    if n_samples >= n_features:
+        L = cholesky(np.dot(X.T, X) + rho * sparse.eye(n_features))
+    else:
+        L = cholesky(sparse.eye(n_samples) + 1. / rho * (np.dot(X, X.T)))
+    L = sparse.csc_matrix(L)
+    U = sparse.csc_matrix(L.T)
+    return L, U


### PR DESCRIPTION
previous instantiation of UoI utilized a coarse sweep followed by a dense sweep in the selection module. This branch changed that by using one sweep, provided by alphagrid, to calculate the selection profiles. This sweep will most likely drop false negatives but increase false positives, due to the diversity among selection profiles. 

The score in the estimation module becomes important for this choice of sweep. AIC and AICc have been added, as they may be useful in these cases.