### PR TITLE
Updated .flake8 to ignore W503 and W504

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,4 @@
 [flake8]
-ignore = E401
+ignore = E401,W503,W504
 max-line-length = 80
-exclude = pyuoi/linear_model/logistic.py,pyuoi/linear_model/utils.py,pyuoi/linear_model/__init__.py,pyuoi/UoINMF.py,pyuoi/__init__.py,pyuoi/mpi_utils.py,bin/run_uoinmf.py,tests/,pyuoi/linear_model/poisson.py
-
+exclude = pyuoi/linear_model/__init__.py,pyuoi/UoINMF.py,pyuoi/__init__.py,pyuoi/mpi_utils.py,bin/run_uoinmf.py,tests/,pyuoi/linear_model/poisson.py


### PR DESCRIPTION
This refers to trailing and leading binary operators