### PR TITLE
Stability Selection unit tests

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,49 +1,116 @@
 import numpy as np
-from numpy.testing import assert_array_equal, assert_array_almost_equal_nulp
+from numpy.testing import assert_array_equal, assert_raises
 
 from pyuoi.linear_model.utils import stability_selection_to_threshold
 
 
 def test_stability_selection_to_threshold_int():
+    """Tests whether stability_selection_to_threshold correctly outputs the
+    correct threshold when provided a single integer."""
+
     n_boots_sel = 48
     # stability selection is a single integer
     test_int = 36
     selection_thresholds = stability_selection_to_threshold(
         test_int, n_boots_sel)
-    assert_array_equal(selection_thresholds, [36])
+
+    assert_array_equal(selection_thresholds, np.array([36]))
 
 
 def test_stability_selection_to_threshold_float():
+    """Tests whether stability_selection_to_threshold correctly outputs the
+    correct threshold when provided a single float."""
+
     n_boots_sel = 48
     # stability selection is a single float
     test_float = 0.5
     selection_thresholds = stability_selection_to_threshold(
         test_float, n_boots_sel)
-    assert_array_equal(selection_thresholds, [24])
+
+    assert_array_equal(selection_thresholds, np.array([24]))
 
 
 def test_stability_selection_to_threshold_ints():
-    # TODO: test stability selection function using a list of ints
-    pass
+    """Tests whether stability_selection_to_threshold correctly outputs the
+    correct threshold when provided a list of ints."""
+
+    n_boots_sel = 48
+    # stability selection is a list of ints
+    test_ints = [24, 28, 33, 38, 43, 48]
+    selection_thresholds = stability_selection_to_threshold(
+        test_ints, n_boots_sel)
+
+    assert_array_equal(
+        selection_thresholds,
+        np.array([24, 28, 33, 38, 43, 48]))
 
 
 def test_stability_selection_to_threshold_floats():
+    """Tests whether stability_selection_to_threshold correctly outputs the
+    correct threshold when provided a list of floats."""
     n_boots_sel = 48
     # stability selection is a list of floats
     test_floats = [0.5, 0.6, 0.7, 0.8, 0.9, 1.0]
     selection_thresholds = stability_selection_to_threshold(
         test_floats, n_boots_sel)
-    assert_array_equal(selection_thresholds, [24, 28, 33, 38, 43, 48])
+
+    assert_array_equal(
+        selection_thresholds,
+        np.array([24, 28, 33, 38, 43, 48]))
 
 
 def test_stability_selection_to_threshold_ints_np():
-    # TODO: test stability selection using a numpy array of ints
-    pass
+    """Tests whether stability_selection_to_threshold correctly outputs the
+    correct threshold when provided a numpy array of ints."""
+
+    n_boots_sel = 48
+    # stability selection is a list of ints
+    test_ints_np = np.array([24, 28, 33, 38, 43, 48])
+    selection_thresholds = stability_selection_to_threshold(
+        test_ints_np, n_boots_sel)
+
+    assert_array_equal(
+        selection_thresholds,
+        np.array([24, 28, 33, 38, 43, 48]))
 
 
 def test_stability_selection_to_threshold_floats_np():
-    # TODO: test stability selection using a numpy array of floats
+    """Tests whether stability_selection_to_threshold correctly outputs the
+    correct threshold when provided a numpy array of ints."""
+
+    n_boots_sel = 48
+    # stability selection is a list of floats
+    test_floats_np = np.array([0.5, 0.6, 0.7, 0.8, 0.9, 1.0])
+    selection_thresholds = stability_selection_to_threshold(
+        test_floats_np, n_boots_sel)
+
+    assert_array_equal(
+        selection_thresholds,
+        np.array([24, 28, 33, 38, 43, 48]))
     pass
+
+
+def test_stability_selection_to_threshold_exceeds_n_bootstraps():
+    """Tests whether stability_selection_to_threshold correctly outputs an
+    error when provided an input that results in bootstraps exceeding
+    n_boots_sel."""
+
+    n_boots_sel = 48
+    # stability selection is a list of floats
+    test_floats = np.array([0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.1])
+    test_ints = np.array([24, 28, 33, 38, 43, 48, 52])
+
+    assert_raises(
+        ValueError,
+        stability_selection_to_threshold,
+        test_ints,
+        n_boots_sel)
+
+    assert_raises(
+        ValueError,
+        stability_selection_to_threshold,
+        test_floats,
+        n_boots_sel)
 
 
 def test_stability_selection_edge_case():


### PR DESCRIPTION
Stability Selection unit tests for int, float, list of ints, list of floats, np array of ints, np array of floats, along with a check to ensure that selection thresholds don't go above number of bootstraps. Closes #45.