### PR TITLE
mpi4py is no longer a requirement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,6 @@ language: python
 python:
     - 3.5
     - 3.6
-before_install:
-    - sudo apt-get update
-    - sudo apt-get install -y openmpi-bin libopenmpi-dev
 install:
     - pip install -r requirements-dev.txt
     - pip install codecov

--- a/pyuoi/mpi_utils.py
+++ b/pyuoi/mpi_utils.py
@@ -10,7 +10,7 @@ try:
                np.dtype(np.float64): MPI.DOUBLE,
                np.dtype(np.int): MPI.LONG,
                np.dtype(np.intc): MPI.INT}
-except ModuleNotFoundError:
+except ImportError:
     import warnings
     warnings.warn('MPI not installed.')
 

--- a/pyuoi/mpi_utils.py
+++ b/pyuoi/mpi_utils.py
@@ -4,11 +4,15 @@ Helper functions for working with MPI.
 import h5py
 import numpy as np
 
-from mpi4py import MPI
-_np2mpi = {np.dtype(np.float32): MPI.FLOAT,
-           np.dtype(np.float64): MPI.DOUBLE,
-           np.dtype(np.int): MPI.LONG,
-           np.dtype(np.intc): MPI.INT}
+try:
+    from mpi4py import MPI
+    _np2mpi = {np.dtype(np.float32): MPI.FLOAT,
+               np.dtype(np.float64): MPI.DOUBLE,
+               np.dtype(np.int): MPI.LONG,
+               np.dtype(np.intc): MPI.INT}
+except ModuleNotFoundError:
+    import warnings
+    warnings.warn('MPI not installed.')
 
 
 def load_data_MPI(h5_name, X_key='X', y_key='y', root=0):

--- a/pyuoi/mpi_utils.py
+++ b/pyuoi/mpi_utils.py
@@ -11,8 +11,7 @@ try:
                np.dtype(np.int): MPI.LONG,
                np.dtype(np.intc): MPI.INT}
 except ImportError:
-    import warnings
-    warnings.warn('MPI not installed.')
+    pass
 
 
 def load_data_MPI(h5_name, X_key='X', y_key='y', root=0):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 h5py
 scikit-learn
 numpy
-mpi4py

--- a/tests/test_mpi/test_mpi_uoi_l1logistic.py
+++ b/tests/test_mpi/test_mpi_uoi_l1logistic.py
@@ -3,7 +3,7 @@ import numpy as np
 from numpy.testing import assert_array_equal, assert_allclose
 try:
     from mpi4py import MPI
-except ModuleNotFoundError:
+except ImportError:
     MPI = None
 
 from pyuoi import UoI_L1Logistic

--- a/tests/test_mpi/test_mpi_uoi_l1logistic.py
+++ b/tests/test_mpi/test_mpi_uoi_l1logistic.py
@@ -1,19 +1,16 @@
 import pytest
-
 import numpy as np
 from numpy.testing import assert_array_equal, assert_allclose
 try:
     from mpi4py import MPI
-    comm = MPI.COMM_WORLD
 except ModuleNotFoundError:
-    import warnings
-    warnings.warn('MPI not installed.')
-    comm = None
+    MPI = None
 
 from pyuoi import UoI_L1Logistic
 from pyuoi.utils import make_classification
 
 
+@pytest.mark.skipif(MPI is None, reason='MPI not installed.')
 def test_l1logistic_binary():
     """Test that binary L1 Logistic runs in the UoI framework."""
     n_inf = 4
@@ -22,11 +19,12 @@ def test_l1logistic_binary():
                                      n_informative=n_inf,
                                      n_features=6)
 
-    l1log = UoI_L1Logistic(random_state=10, comm=comm).fit(X, y)
+    l1log = UoI_L1Logistic(random_state=10, comm=MPI.COMM_WORLD).fit(X, y)
     assert_array_equal(np.sign(w), np.sign(l1log.coef_))
     assert_allclose(w, l1log.coef_, atol=.5, rtol=.5)
 
 
+@pytest.mark.skip(reason="Logistic is not currently finished")
 def test_l1logistic_multiclass():
     """Test that multiclass L1 Logistic runs in the UoI framework when all
        classes share a support."""
@@ -38,7 +36,7 @@ def test_l1logistic_multiclass():
                                      n_informative=n_inf,
                                      n_features=n_features,
                                      shared_support=True)
-    l1log = UoI_L1Logistic(comm=comm).fit(X, y)
+    l1log = UoI_L1Logistic(comm=MPI.COMM_WORLD).fit(X, y)
     print()
     print(w)
     print(l1log.coef_)

--- a/tests/test_mpi/test_mpi_uoi_l1logistic.py
+++ b/tests/test_mpi/test_mpi_uoi_l1logistic.py
@@ -2,7 +2,13 @@ import pytest
 
 import numpy as np
 from numpy.testing import assert_array_equal, assert_allclose
-from mpi4py import MPI
+try:
+    from mpi4py import MPI
+    comm = MPI.COMM_WORLD
+except ModuleNotFoundError:
+    import warnings
+    warnings.warn('MPI not installed.')
+    comm = None
 
 from pyuoi import UoI_L1Logistic
 from pyuoi.utils import make_classification
@@ -16,12 +22,11 @@ def test_l1logistic_binary():
                                      n_informative=n_inf,
                                      n_features=6)
 
-    l1log = UoI_L1Logistic(random_state=10, comm=MPI.COMM_WORLD).fit(X, y)
+    l1log = UoI_L1Logistic(random_state=10, comm=comm).fit(X, y)
     assert_array_equal(np.sign(w), np.sign(l1log.coef_))
     assert_allclose(w, l1log.coef_, atol=.5, rtol=.5)
 
 
-@pytest.mark.skip(reason="Logistic is not currently finished")
 def test_l1logistic_multiclass():
     """Test that multiclass L1 Logistic runs in the UoI framework when all
        classes share a support."""
@@ -33,7 +38,7 @@ def test_l1logistic_multiclass():
                                      n_informative=n_inf,
                                      n_features=n_features,
                                      shared_support=True)
-    l1log = UoI_L1Logistic(comm=MPI.COMM_WORLD).fit(X, y)
+    l1log = UoI_L1Logistic(comm=comm).fit(X, y)
     print()
     print(w)
     print(l1log.coef_)

--- a/tests/test_mpi/test_mpi_uoi_lasso.py
+++ b/tests/test_mpi/test_mpi_uoi_lasso.py
@@ -4,7 +4,7 @@ from numpy.testing import assert_array_equal, assert_array_almost_equal_nulp
 from sklearn.datasets import make_regression
 try:
     from mpi4py import MPI
-except ModuleNotFoundError:
+except ImportError:
     MPI = None
 
 from pyuoi import UoI_Lasso

--- a/tests/test_mpi/test_mpi_uoi_lasso.py
+++ b/tests/test_mpi/test_mpi_uoi_lasso.py
@@ -1,11 +1,16 @@
+import pytest
 import numpy as np
 from numpy.testing import assert_array_equal, assert_array_almost_equal_nulp
-from mpi4py import MPI
 from sklearn.datasets import make_regression
+try:
+    from mpi4py import MPI
+except ModuleNotFoundError:
+    MPI = None
 
 from pyuoi import UoI_Lasso
 
 
+@pytest.mark.skipif(MPI is None, reason='MPI not installed.')
 def test_variable_selection():
     """Test basic functionality of UoI_Lasso and that it finds right model"""
     X, y, w = make_regression(coef=True, random_state=1)

--- a/tests/test_mpi/test_mpi_utils.py
+++ b/tests/test_mpi/test_mpi_utils.py
@@ -1,13 +1,17 @@
-import h5py
+import h5py, pytest
 import numpy as np
 
 from numpy.testing import assert_array_equal
-from mpi4py import MPI
+try:
+    from mpi4py import MPI
+except ModuleNotFoundError:
+    MPI = None
 
 from pyuoi.mpi_utils import (Bcast_from_root, Gatherv_rows,
                              load_data_MPI)
 
 
+@pytest.mark.skipif(MPI is None, reason='MPI not installed.')
 def test_load_data_MPI(tmpdir):
     """Tests loading data from an HDF5 file into all ranks.
     """
@@ -40,6 +44,7 @@ def test_load_data_MPI(tmpdir):
         assert_array_equal(y, y_load)
 
 
+@pytest.mark.skipif(MPI is None, reason='MPI not installed.')
 def test_Bcast_from_root():
     """Test the Bcast_from_root function for broadcasting
     an array from root to all ranks.
@@ -64,6 +69,7 @@ def test_Bcast_from_root():
             assert X.ndim == len(my_dim)
 
 
+@pytest.mark.skipif(MPI is None, reason='MPI not installed.')
 def test_Gatherv_rows():
     """Test the Gatherv_rows function for Gathering and
     concatenating ndarrys along their first axes to root.

--- a/tests/test_mpi/test_mpi_utils.py
+++ b/tests/test_mpi/test_mpi_utils.py
@@ -4,7 +4,7 @@ import numpy as np
 from numpy.testing import assert_array_equal
 try:
     from mpi4py import MPI
-except ImportFoundError:
+except ImportError:
     MPI = None
 
 from pyuoi.mpi_utils import (Bcast_from_root, Gatherv_rows,

--- a/tests/test_mpi/test_mpi_utils.py
+++ b/tests/test_mpi/test_mpi_utils.py
@@ -4,7 +4,7 @@ import numpy as np
 from numpy.testing import assert_array_equal
 try:
     from mpi4py import MPI
-except ModuleNotFoundError:
+except ImportFoundError:
     MPI = None
 
 from pyuoi.mpi_utils import (Bcast_from_root, Gatherv_rows,


### PR DESCRIPTION
This should allow people to use the non-mpi parts without install mpi4py. It should also allow the docs to build again.