### PR TITLE
Gatherv fix

### DIFF
--- a/pyuoi/mpi_utils.py
+++ b/pyuoi/mpi_utils.py
@@ -120,13 +120,16 @@ def Gatherv_rows(send, comm, root=0):
     dtype = send.dtype
     shape = send.shape
     tot = np.zeros(1, dtype=int)
+    
+    # Gather the sizes of the first dimension on root   
+    rank_sizes = comm.gather(shape[0], root = root)
     comm.Reduce(np.array(shape[0], dtype=int),
                 [tot, _np2mpi[tot.dtype]], op=MPI.SUM, root=root)
     if rank == root:
         rec_shape = (tot[0],) + shape[1:]
         rec = np.empty(rec_shape, dtype=dtype)
-        idxs = np.array_split(np.arange(rec_shape[0]), size)
-        sizes = [idx.size * np.prod(rec_shape[1:]) for idx in idxs]
+        #idxs = np.array_split(np.arange(rec_shape[0]), size)
+        sizes = [size * np.prod(rec_shape[1:]) for size in rank_sizes]
         disps = np.insert(np.cumsum(sizes), 0, 0)[:-1]
     else:
         rec = None

--- a/pyuoi/mpi_utils.py
+++ b/pyuoi/mpi_utils.py
@@ -116,13 +116,12 @@ def Gatherv_rows(send, comm, root=0):
     """
 
     rank = comm.rank
-    size = comm.size
     dtype = send.dtype
     shape = send.shape
     tot = np.zeros(1, dtype=int)
-    
-    # Gather the sizes of the first dimension on root   
-    rank_sizes = comm.gather(shape[0], root = root)
+
+    # Gather the sizes of the first dimension on root
+    rank_sizes = comm.gather(shape[0], root=root)
     comm.Reduce(np.array(shape[0], dtype=int),
                 [tot, _np2mpi[tot.dtype]], op=MPI.SUM, root=root)
     if rank == root:
@@ -132,7 +131,6 @@ def Gatherv_rows(send, comm, root=0):
         disps = np.insert(np.cumsum(sizes), 0, 0)[:-1]
     else:
         rec = None
-        idxs = None
         sizes = None
         disps = None
 

--- a/pyuoi/mpi_utils.py
+++ b/pyuoi/mpi_utils.py
@@ -128,7 +128,6 @@ def Gatherv_rows(send, comm, root=0):
     if rank == root:
         rec_shape = (tot[0],) + shape[1:]
         rec = np.empty(rec_shape, dtype=dtype)
-        #idxs = np.array_split(np.arange(rec_shape[0]), size)
         sizes = [size * np.prod(rec_shape[1:]) for size in rank_sizes]
         disps = np.insert(np.cumsum(sizes), 0, 0)[:-1]
     else:

--- a/tests/test_mpi/test_mpi_utils.py
+++ b/tests/test_mpi/test_mpi_utils.py
@@ -7,9 +7,6 @@ try:
 except ImportError:
     MPI = None
 
-import sys 
-sys.path.append('../..')
-
 from pyuoi.mpi_utils import (Bcast_from_root, Gatherv_rows,
                              load_data_MPI)
 

--- a/tests/test_mpi/test_mpi_utils.py
+++ b/tests/test_mpi/test_mpi_utils.py
@@ -10,6 +10,7 @@ except ImportError:
 from pyuoi.mpi_utils import (Bcast_from_root, Gatherv_rows,
                              load_data_MPI)
 
+
 @pytest.mark.skipif(MPI is None, reason='MPI not installed.')
 def test_load_data_MPI(tmpdir):
     """Tests loading data from an HDF5 file into all ranks.
@@ -111,20 +112,20 @@ def test_Gatherv_rows():
             assert_array_equal(X, Xp)
             assert Xp.dtype == dtype
 
+
 @pytest.mark.skipif(MPI is None, reason='MPI not installed.')
 def test_Gatherv_random_rows():
     """Test Gatherv_rows for gathering ndarrays with random
     shapes along their first axis
     """
-    
+
     comm = MPI.COMM_WORLD
     root = 0
     rank = comm.rank
-    
-    data  = np.random.normal(size = (np.random.randint(1, 10), 1000))
-    sizes = comm.gather(data.shape[0], root = root)
+
+    data = np.random.normal(size=(np.random.randint(1, 10), 1000))
+    sizes = comm.gather(data.shape[0], root=root)
     data = Gatherv_rows(data, comm, root)
-    
+
     if rank == root:
         assert(data.shape[0] == np.sum(sizes))
-    

--- a/tests/test_mpi/test_mpi_utils.py
+++ b/tests/test_mpi/test_mpi_utils.py
@@ -7,9 +7,11 @@ try:
 except ImportError:
     MPI = None
 
+import sys 
+sys.path.append('../..')
+
 from pyuoi.mpi_utils import (Bcast_from_root, Gatherv_rows,
                              load_data_MPI)
-
 
 @pytest.mark.skipif(MPI is None, reason='MPI not installed.')
 def test_load_data_MPI(tmpdir):
@@ -111,3 +113,21 @@ def test_Gatherv_rows():
         if rank == root:
             assert_array_equal(X, Xp)
             assert Xp.dtype == dtype
+
+@pytest.mark.skipif(MPI is None, reason='MPI not installed.')
+def test_Gatherv_random_rows():
+    """Test Gatherv_rows for gathering ndarrays with random
+    shapes along their first axis
+    """
+    
+    comm = MPI.COMM_WORLD
+    root = 0
+    rank = comm.rank
+    
+    data  = np.random.normal(size = (np.random.randint(1, 10), 1000))
+    sizes = comm.gather(data.shape[0], root = root)
+    data = Gatherv_rows(data, comm, root)
+    
+    if rank == root:
+        assert(data.shape[0] == np.sum(sizes))
+    


### PR DESCRIPTION
Gatherv could not concatenate arrays of arbitrary length of first dimension. Fixed this, and added a test to test_mpi_utils for this functionality.