### PR TITLE
Modify linear_model inheritance to use predict() and score() from sklearn

### DIFF
--- a/pyuoi/linear_model/base.py
+++ b/pyuoi/linear_model/base.py
@@ -3,8 +3,7 @@ import six as _six
 import numpy as np
 
 
-from sklearn.linear_model.base import (
-    LinearModel, _preprocess_data, SparseCoefMixin)
+from sklearn.linear_model.base import _preprocess_data, SparseCoefMixin
 from sklearn.metrics import r2_score, accuracy_score, log_loss
 from sklearn.model_selection import train_test_split
 from sklearn.utils import check_X_y

--- a/pyuoi/linear_model/base.py
+++ b/pyuoi/linear_model/base.py
@@ -16,7 +16,7 @@ from .utils import stability_selection_to_threshold, intersection
 
 
 class AbstractUoILinearModel(
-        _six.with_metaclass(_abc.ABCMeta, LinearModel, SparseCoefMixin)):
+        _six.with_metaclass(_abc.ABCMeta, SparseCoefMixin)):
     """An abstract base class for UoI linear model classes
 
     See Bouchard et al., NIPS, 2017, for more details on the Union of
@@ -777,6 +777,7 @@ class AbstractUoILinearClassifier(
         # perform checks
         X, y = check_X_y(X, y, accept_sparse=['csr', 'csc', 'coo'],
                          y_numeric=True, multi_output=True)
+        self.classes_ = np.array(sorted(set(y)))
         # preprocess data
         super(AbstractUoILinearClassifier, self).fit(X, y, stratify=stratify,
                                                      verbose=verbose)

--- a/pyuoi/linear_model/elasticnet.py
+++ b/pyuoi/linear_model/elasticnet.py
@@ -7,7 +7,7 @@ from sklearn.linear_model.coordinate_descent import _alpha_grid
 from sklearn.linear_model import ElasticNet
 
 
-class UoI_ElasticNet(AbstractUoILinearRegressor):
+class UoI_ElasticNet(AbstractUoILinearRegressor, LinearRegression):
 
     def __init__(self, n_lambdas=48, alphas=np.array([0.5]),
                  n_boots_sel=48, n_boots_est=48, selection_frac=0.9,

--- a/pyuoi/linear_model/lasso.py
+++ b/pyuoi/linear_model/lasso.py
@@ -4,7 +4,7 @@ from sklearn.linear_model.coordinate_descent import _alpha_grid
 from .base import AbstractUoILinearRegressor
 
 
-class UoI_Lasso(AbstractUoILinearRegressor):
+class UoI_Lasso(AbstractUoILinearRegressor, LinearRegression):
 
     def __init__(self, n_boots_sel=48, n_boots_est=48, selection_frac=0.9,
                  estimation_frac=0.9, n_lambdas=48, stability_selection=1.,

--- a/pyuoi/linear_model/logistic.py
+++ b/pyuoi/linear_model/logistic.py
@@ -26,7 +26,7 @@ from ..utils import sigmoid, softmax
 from ..lbfgs import fmin_lbfgs
 
 
-class UoI_L1Logistic(AbstractUoILinearClassifier):
+class UoI_L1Logistic(AbstractUoILinearClassifier, LogisticRegression):
 
     def __init__(self, n_boots_sel=48, n_boots_est=48, selection_frac=0.9,
                  estimation_frac=0.9, n_C=48, stability_selection=1.,

--- a/tests/test_elasticnet.py
+++ b/tests/test_elasticnet.py
@@ -1,8 +1,11 @@
 import numpy as np
 from numpy.testing import (assert_array_equal, assert_array_almost_equal_nulp,
                            assert_equal, assert_allclose)
+
 from sklearn.datasets import make_regression
 from sklearn.linear_model import ElasticNet
+from sklearn.metrics import r2_score
+
 from pyuoi import UoI_ElasticNet
 
 
@@ -30,8 +33,8 @@ def test_estimation_score_usage():
         enet = UoI_ElasticNet(estimation_score=method)
         assert_equal(enet.estimation_score, method)
         enet.fit(X, y)
-        enet.predict(X)
-        enet.score(X, y)
+        y_hat = enet.predict(X)
+        assert_equal(r2_score(y, y_hat), enet.score(X, y))
         score = np.max(enet.scores_)
         scores.append(score)
     assert_equal(len(np.unique(scores)), len(methods))

--- a/tests/test_elasticnet.py
+++ b/tests/test_elasticnet.py
@@ -31,7 +31,7 @@ def test_estimation_score_usage():
         assert_equal(enet.estimation_score, method)
         enet.fit(X, y)
         enet.predict(X)
-        enet.score(X)
+        enet.score(X, y)
         score = np.max(enet.scores_)
         scores.append(score)
     assert_equal(len(np.unique(scores)), len(methods))

--- a/tests/test_lbfgs.py
+++ b/tests/test_lbfgs.py
@@ -27,8 +27,6 @@ class TestOWLQN:
 
         xmin = fmin_lbfgs(f, np.zeros(10), orthantwise_c=1.,
                           orthantwise_end=5)
-        print()
-        print(xmin)
         assert_array_equal(xmin[5:], 1.)
         assert np.all(xmin[:5] < 1.)
 

--- a/tests/test_uoi_l1logistic.py
+++ b/tests/test_uoi_l1logistic.py
@@ -83,6 +83,8 @@ def test_l1logistic_binary():
                                      include_intercept=True)
 
     l1log = UoI_L1Logistic(random_state=10).fit(X, y)
+    l1log.predict(X)
+    l1log.score(X, y)
     assert (np.sign(abs(w)) == np.sign(abs(l1log.coef_))).mean() >= .8
 
 
@@ -99,6 +101,8 @@ def test_l1logistic_multiclass():
                                      shared_support=True,
                                      w_scale=4.)
     l1log = UoI_L1Logistic().fit(X, y)
+    l1log.predict(X)
+    l1log.score(X, y)
     assert (np.sign(abs(w)) == np.sign(abs(l1log.coef_))).mean() >= .8
 
 

--- a/tests/test_uoi_l1logistic.py
+++ b/tests/test_uoi_l1logistic.py
@@ -6,6 +6,8 @@ from pyuoi import UoI_L1Logistic
 from pyuoi.linear_model.logistic import (fit_intercept_fixed_coef,
                                          MaskedCoefLogisticRegression,
                                          LogisticInterceptFitterNoFeatures)
+from sklearn.metrics import accuracy_score
+
 from pyuoi.utils import make_classification
 
 
@@ -83,8 +85,8 @@ def test_l1logistic_binary():
                                      include_intercept=True)
 
     l1log = UoI_L1Logistic(random_state=10).fit(X, y)
-    l1log.predict(X)
-    l1log.score(X, y)
+    y_hat = l1log.predict(X)
+    assert_equal(accuracy_score(y, y_hat), l1log.score(X, y))
     assert (np.sign(abs(w)) == np.sign(abs(l1log.coef_))).mean() >= .8
 
 
@@ -101,8 +103,8 @@ def test_l1logistic_multiclass():
                                      shared_support=True,
                                      w_scale=4.)
     l1log = UoI_L1Logistic().fit(X, y)
-    l1log.predict(X)
-    l1log.score(X, y)
+    y_hat = l1log.predict(X)
+    assert_equal(accuracy_score(y, y_hat), l1log.score(X, y))
     assert (np.sign(abs(w)) == np.sign(abs(l1log.coef_))).mean() >= .8
 
 
@@ -119,6 +121,8 @@ def test_l1logistic_multiclass_not_shared():
                                      shared_support=False,
                                      w_scale=4.)
     l1log = UoI_L1Logistic(shared_support=False).fit(X, y)
+    y_hat = l1log.predict(X)
+    assert_equal(accuracy_score(y, y_hat), l1log.score(X, y))
     assert (np.sign(abs(w)) == np.sign(abs(l1log.coef_))).mean() >= .8
 
 

--- a/tests/test_uoi_lasso.py
+++ b/tests/test_uoi_lasso.py
@@ -30,7 +30,7 @@ def test_estimation_score_usage():
         assert_equal(lasso.estimation_score, method)
         lasso.fit(X, y)
         lasso.predict(X)
-        lasso.score(X)
+        lasso.score(X, y)
         score = np.max(lasso.scores_)
         scores.append(score)
     assert_equal(len(np.unique(scores)), len(methods))

--- a/tests/test_uoi_lasso.py
+++ b/tests/test_uoi_lasso.py
@@ -1,8 +1,11 @@
 import numpy as np
 from numpy.testing import (assert_array_equal, assert_array_almost_equal_nulp,
                            assert_equal, assert_allclose)
+
 from sklearn.datasets import make_regression
 from sklearn.linear_model import Lasso
+from sklearn.metrics import r2_score
+
 from pyuoi import UoI_Lasso
 
 
@@ -29,8 +32,8 @@ def test_estimation_score_usage():
         lasso = UoI_Lasso(estimation_score=method)
         assert_equal(lasso.estimation_score, method)
         lasso.fit(X, y)
-        lasso.predict(X)
-        lasso.score(X, y)
+        y_hat = lasso.predict(X)
+        assert_equal(r2_score(y, y_hat), lasso.score(X, y))
         score = np.max(lasso.scores_)
         scores.append(score)
     assert_equal(len(np.unique(scores)), len(methods))


### PR DESCRIPTION
Adds elastic net tests and add predict() and score() tests should fail before the next commits.

The goal is to have UoI classes in `linear_models` be able to inherit the `predict` and `score` methods from the sklearn counterparts, i.e., LogisticRegression or LinearRegression. However, the way the hierarchy was setup, they would all inherit them from `sklearn.LinearModel` first, and that meant all classes used the `predict` and `score` for LinearRegression.

This removes `LinearModel` (explicitly) from the hierarchy since we are not really using any of that functionality anyway. All models will still inherit from `LinearModel` through their respective sklearn counterparts.

Closes #91 