### PR TITLE
[WIP] Fix input normalization and estimation frac

### DIFF
--- a/pyuoi/linear_model/__init__.py
+++ b/pyuoi/linear_model/__init__.py
@@ -4,7 +4,7 @@ Provides both abstract base classes for creating user-defined UoI models
 and several concrete implementations.
 """
 from .base import (AbstractUoILinearModel, AbstractUoILinearRegressor,
-                   AbstractUoILinearClassifier)
+                   AbstractUoIGeneralizedLinearRegressor)
 from .lasso import UoI_Lasso
 from .elasticnet import UoI_ElasticNet
 from .logistic import UoI_L1Logistic
@@ -12,9 +12,9 @@ from .poisson import Poisson
 from .poisson import UoI_Poisson
 from . import utils
 
-__all__ = ["AbstractUoILinearClassifier",
-           "AbstractUoILinearModel",
+__all__ = ["AbstractUoILinearModel",
            "AbstractUoILinearRegressor",
+           "AbstractUoIGeneralizedLinearRegressor",
            "UoI_L1Logistic",
            "UoI_Lasso",
            "UoI_ElasticNet",

--- a/pyuoi/linear_model/base.py
+++ b/pyuoi/linear_model/base.py
@@ -324,7 +324,7 @@ class AbstractUoILinearModel(
             if self.comm is not None:
                 if rank == 0:
                     rvals = train_test_split(np.arange(X.shape[0]),
-                                             test_size=1 - self.selection_frac,
+                                             test_size=1 - self.estimation_frac,
                                              stratify=stratify,
                                              random_state=self.random_state)
                 else:
@@ -336,7 +336,7 @@ class AbstractUoILinearModel(
             else:
                 my_boots[boot] = train_test_split(
                     np.arange(X.shape[0]),
-                    test_size=1 - self.selection_frac,
+                    test_size=1 - self.estimation_frac,
                     stratify=stratify,
                     random_state=self.random_state)
 

--- a/pyuoi/linear_model/base.py
+++ b/pyuoi/linear_model/base.py
@@ -445,18 +445,6 @@ class AbstractUoILinearModel(
             X = self._X_scaler.transform(X)
         return super().predict(X)
 
-    def predict_proba(self, X):
-        """Predict the output log probabilities."""
-        if self.standardize:
-            X = self._X_scaler.transform(X)
-        raise NotImplementedError
-
-    def predict_log_proba(self, X):
-        """Predict the output probabilities."""
-        if self.standardize:
-            X = self._X_scaler.transform(X)
-        raise NotImplementedError
-
     def get_n_coef(self, X, y):
         """"Return the number of coefficients that will be estimated
 
@@ -590,7 +578,7 @@ class AbstractUoILinearClassifier(
     Intersections framework.
     """
 
-    __valid_estimation_metrics = ('acc', 'log')
+    __valid_estimation_metrics = ('acc', 'log', 'BIC', 'AIC', 'AICc')
 
     def __init__(self, n_boots_sel=48, n_boots_est=48, selection_frac=0.9,
                  estimation_frac=0.9, stability_selection=1.,
@@ -702,15 +690,3 @@ class AbstractUoILinearClassifier(
                 score = -score
 
         return score
-
-    def predict_proba(self, X):
-        """Predict the ouput log probabilities."""
-        if self.standardize:
-            X = self._X_scaler.transform(X)
-        return super().predict_proba(X)
-
-    def predict_log_proba(self, X):
-        """Predict the ouput probabilities."""
-        if self.standardize:
-            X = self._X_scaler.transform(X)
-        return super().predict_log_proba(X)

--- a/pyuoi/linear_model/elasticnet.py
+++ b/pyuoi/linear_model/elasticnet.py
@@ -36,21 +36,13 @@ class UoI_ElasticNet(AbstractUoILinearRegressor, LinearRegression):
         self.warm_start = warm_start
         self.eps = eps
         self.lambdas = None
-        self.__selection_lm = ElasticNet(
+        self.selection_lm = ElasticNet(
             fit_intercept=fit_intercept,
             max_iter=max_iter,
             copy_X=copy_X,
             warm_start=warm_start,
             random_state=random_state)
-        self.__estimation_lm = LinearRegression()
-
-    @property
-    def estimation_lm(self):
-        return self.__estimation_lm
-
-    @property
-    def selection_lm(self):
-        return self.__selection_lm
+        self.estimation_lm = LinearRegression()
 
     def get_reg_params(self, X, y):
         """Calculates the regularization parameters (alpha and lambda) to be
@@ -107,6 +99,6 @@ class UoI_ElasticNet(AbstractUoILinearRegressor, LinearRegression):
     def _fit_intercept(self, X, y):
         """Fit the intercept."""
         if self.fit_intercept:
-            self.intercept_ = y.mean() - np.dot(X.mean(axis=0), self.coef_)
+            self.intercept_ = y.mean() - np.dot(X.mean(axis=0), self.coef_.T)
         else:
             self.intercept = np.zeros(1)

--- a/pyuoi/linear_model/elasticnet.py
+++ b/pyuoi/linear_model/elasticnet.py
@@ -13,7 +13,7 @@ class UoI_ElasticNet(AbstractUoILinearRegressor, LinearRegression):
                  n_boots_sel=48, n_boots_est=48, selection_frac=0.9,
                  estimation_frac=0.9, stability_selection=1.,
                  estimation_score='r2', warm_start=True, eps=1e-3,
-                 copy_X=True, fit_intercept=True, normalize=True,
+                 copy_X=True, fit_intercept=True, standardize=True,
                  random_state=None, max_iter=1000,
                  comm=None):
         super(UoI_ElasticNet, self).__init__(
@@ -25,9 +25,10 @@ class UoI_ElasticNet(AbstractUoILinearRegressor, LinearRegression):
             estimation_score=estimation_score,
             copy_X=copy_X,
             fit_intercept=fit_intercept,
-            normalize=normalize,
+            standardize=standardize,
             random_state=random_state,
-            comm=comm
+            comm=comm,
+            max_iter=max_iter,
         )
         self.n_lambdas = n_lambdas
         self.alphas = alphas
@@ -37,7 +38,6 @@ class UoI_ElasticNet(AbstractUoILinearRegressor, LinearRegression):
         self.lambdas = None
         self.__selection_lm = ElasticNet(
             fit_intercept=fit_intercept,
-            normalize=normalize,
             max_iter=max_iter,
             copy_X=copy_X,
             warm_start=warm_start,
@@ -93,8 +93,7 @@ class UoI_ElasticNet(AbstractUoILinearRegressor, LinearRegression):
                     l1_ratio=alpha,
                     fit_intercept=self.fit_intercept,
                     eps=self.eps,
-                    n_alphas=self.n_lambdas,
-                    normalize=self.normalize)
+                    n_alphas=self.n_lambdas)
 
         # place the regularization parameters into a list of dictionaries
         reg_params = list()
@@ -105,10 +104,9 @@ class UoI_ElasticNet(AbstractUoILinearRegressor, LinearRegression):
 
         return reg_params
 
-    def _fit_intercept(self, X_offset, y_offset, X_scale):
-        """"Fit a model with an intercept and fixed coefficients.
-
-        This is used to re-fit the intercept after the coefficients are
-        estimated.
-        """
-        self._set_intercept(X_offset, y_offset, X_scale)
+    def _fit_intercept(self, X, y):
+        """Fit the intercept."""
+        if self.fit_intercept:
+            self.intercept_ = y.mean()
+        else:
+            self.intercept = np.zeros(1)

--- a/pyuoi/linear_model/elasticnet.py
+++ b/pyuoi/linear_model/elasticnet.py
@@ -107,6 +107,6 @@ class UoI_ElasticNet(AbstractUoILinearRegressor, LinearRegression):
     def _fit_intercept(self, X, y):
         """Fit the intercept."""
         if self.fit_intercept:
-            self.intercept_ = y.mean()
+            self.intercept_ = y.mean() - np.dot(X.mean(axis=0), self.coef_)
         else:
             self.intercept = np.zeros(1)

--- a/pyuoi/linear_model/elasticnet.py
+++ b/pyuoi/linear_model/elasticnet.py
@@ -36,13 +36,13 @@ class UoI_ElasticNet(AbstractUoILinearRegressor, LinearRegression):
         self.warm_start = warm_start
         self.eps = eps
         self.lambdas = None
-        self.selection_lm = ElasticNet(
+        self._selection_lm = ElasticNet(
             fit_intercept=fit_intercept,
             max_iter=max_iter,
             copy_X=copy_X,
             warm_start=warm_start,
             random_state=random_state)
-        self.estimation_lm = LinearRegression()
+        self._estimation_lm = LinearRegression()
 
     def get_reg_params(self, X, y):
         """Calculates the regularization parameters (alpha and lambda) to be
@@ -95,11 +95,3 @@ class UoI_ElasticNet(AbstractUoILinearRegressor, LinearRegression):
                 reg_params.append(dict(alpha=lamb, l1_ratio=alpha))
 
         return reg_params
-
-    def _fit_intercept(self, X, y):
-        """Fit the intercept."""
-        if self.fit_intercept:
-            self.intercept_ = (y.mean(axis=0) -
-                               np.dot(X.mean(axis=0), self.coef_.T))
-        else:
-            self.intercept = np.zeros(1)

--- a/pyuoi/linear_model/elasticnet.py
+++ b/pyuoi/linear_model/elasticnet.py
@@ -99,6 +99,7 @@ class UoI_ElasticNet(AbstractUoILinearRegressor, LinearRegression):
     def _fit_intercept(self, X, y):
         """Fit the intercept."""
         if self.fit_intercept:
-            self.intercept_ = y.mean() - np.dot(X.mean(axis=0), self.coef_.T)
+            self.intercept_ = (y.mean(axis=0) -
+                               np.dot(X.mean(axis=0), self.coef_.T))
         else:
             self.intercept = np.zeros(1)

--- a/pyuoi/linear_model/lasso.py
+++ b/pyuoi/linear_model/lasso.py
@@ -58,6 +58,6 @@ class UoI_Lasso(AbstractUoILinearRegressor, LinearRegression):
     def _fit_intercept(self, X, y):
         """Fit the intercept."""
         if self.fit_intercept:
-            self.intercept_ = y.mean()
+            self.intercept_ = y.mean() - np.dot(X.mean(axis=0), self.coef_)
         else:
             self.intercept = np.zeros(1)

--- a/pyuoi/linear_model/lasso.py
+++ b/pyuoi/linear_model/lasso.py
@@ -1,3 +1,5 @@
+import numpy as np
+
 from sklearn.linear_model import Lasso, LinearRegression
 from sklearn.linear_model.coordinate_descent import _alpha_grid
 
@@ -9,7 +11,7 @@ class UoI_Lasso(AbstractUoILinearRegressor, LinearRegression):
     def __init__(self, n_boots_sel=48, n_boots_est=48, selection_frac=0.9,
                  estimation_frac=0.9, n_lambdas=48, stability_selection=1.,
                  eps=1e-3, warm_start=True, estimation_score='r2',
-                 copy_X=True, fit_intercept=True, normalize=True,
+                 copy_X=True, fit_intercept=True, standardize=True,
                  random_state=None, max_iter=1000,
                  comm=None):
         super(UoI_Lasso, self).__init__(
@@ -20,15 +22,15 @@ class UoI_Lasso(AbstractUoILinearRegressor, LinearRegression):
             stability_selection=stability_selection,
             copy_X=copy_X,
             fit_intercept=fit_intercept,
-            normalize=normalize,
+            standardize=standardize,
             random_state=random_state,
             comm=comm,
-            estimation_score=estimation_score
+            estimation_score=estimation_score,
+            max_iter=max_iter
         )
         self.n_lambdas = n_lambdas
         self.eps = eps
         self.__selection_lm = Lasso(
-            normalize=normalize,
             max_iter=max_iter,
             warm_start=warm_start,
             random_state=random_state
@@ -50,14 +52,12 @@ class UoI_Lasso(AbstractUoILinearRegressor, LinearRegression):
             fit_intercept=self.fit_intercept,
             eps=self.eps,
             n_alphas=self.n_lambdas,
-            normalize=self.normalize
         )
         return [{'alpha': a} for a in alphas]
 
-    def _fit_intercept(self, X_offset, y_offset, X_scale):
-        """"Fit a model with an intercept and fixed coefficients.
-
-        This is used to re-fit the intercept after the coefficients are
-        estimated.
-        """
-        self._set_intercept(X_offset, y_offset, X_scale)
+    def _fit_intercept(self, X, y):
+        """Fit the intercept."""
+        if self.fit_intercept:
+            self.intercept_ = y.mean()
+        else:
+            self.intercept = np.zeros(1)

--- a/pyuoi/linear_model/lasso.py
+++ b/pyuoi/linear_model/lasso.py
@@ -1,5 +1,3 @@
-import numpy as np
-
 from sklearn.linear_model import Lasso, LinearRegression
 from sklearn.linear_model.coordinate_descent import _alpha_grid
 
@@ -30,12 +28,12 @@ class UoI_Lasso(AbstractUoILinearRegressor, LinearRegression):
         )
         self.n_lambdas = n_lambdas
         self.eps = eps
-        self.selection_lm = Lasso(
+        self._selection_lm = Lasso(
             max_iter=max_iter,
             warm_start=warm_start,
             random_state=random_state
         )
-        self.estimation_lm = LinearRegression()
+        self._estimation_lm = LinearRegression()
 
     def get_reg_params(self, X, y):
         alphas = _alpha_grid(
@@ -46,11 +44,3 @@ class UoI_Lasso(AbstractUoILinearRegressor, LinearRegression):
             n_alphas=self.n_lambdas,
         )
         return [{'alpha': a} for a in alphas]
-
-    def _fit_intercept(self, X, y):
-        """Fit the intercept."""
-        if self.fit_intercept:
-            self.intercept_ = (y.mean(axis=0) -
-                               np.dot(X.mean(axis=0), self.coef_.T))
-        else:
-            self.intercept = np.zeros(1)

--- a/pyuoi/linear_model/lasso.py
+++ b/pyuoi/linear_model/lasso.py
@@ -50,6 +50,7 @@ class UoI_Lasso(AbstractUoILinearRegressor, LinearRegression):
     def _fit_intercept(self, X, y):
         """Fit the intercept."""
         if self.fit_intercept:
-            self.intercept_ = y.mean() - np.dot(X.mean(axis=0), self.coef_.T)
+            self.intercept_ = (y.mean(axis=0) -
+                               np.dot(X.mean(axis=0), self.coef_.T))
         else:
             self.intercept = np.zeros(1)

--- a/pyuoi/linear_model/lasso.py
+++ b/pyuoi/linear_model/lasso.py
@@ -30,20 +30,12 @@ class UoI_Lasso(AbstractUoILinearRegressor, LinearRegression):
         )
         self.n_lambdas = n_lambdas
         self.eps = eps
-        self.__selection_lm = Lasso(
+        self.selection_lm = Lasso(
             max_iter=max_iter,
             warm_start=warm_start,
             random_state=random_state
         )
-        self.__estimation_lm = LinearRegression()
-
-    @property
-    def estimation_lm(self):
-        return self.__estimation_lm
-
-    @property
-    def selection_lm(self):
-        return self.__selection_lm
+        self.estimation_lm = LinearRegression()
 
     def get_reg_params(self, X, y):
         alphas = _alpha_grid(
@@ -58,6 +50,6 @@ class UoI_Lasso(AbstractUoILinearRegressor, LinearRegression):
     def _fit_intercept(self, X, y):
         """Fit the intercept."""
         if self.fit_intercept:
-            self.intercept_ = y.mean() - np.dot(X.mean(axis=0), self.coef_)
+            self.intercept_ = y.mean() - np.dot(X.mean(axis=0), self.coef_.T)
         else:
             self.intercept = np.zeros(1)

--- a/pyuoi/linear_model/logistic.py
+++ b/pyuoi/linear_model/logistic.py
@@ -98,6 +98,24 @@ class UoI_L1Logistic(AbstractUoILinearClassifier, LogisticRegression):
         else:
             self.intercept_ = np.zeros(self.output_dim)
 
+    def predict_proba(self, X):
+        """Predict the ouput log probabilities."""
+        if self.standardize:
+            X = self._X_scaler.transform(X)
+        logits = self.predict_log_proba(X)
+        if (self.output_dim == 1) or (self.multi_class == 'ovr'):
+            proba = sigmoid(logits)
+        else:
+            proba = softmax(logits)
+        return proba
+
+    def predict_log_proba(self, X):
+        """Predict the ouput probabilities."""
+        if self.standardize:
+            X = self._X_scaler.transform(X)
+        logits = X.dot(self.coef_.T) + self.intercept_
+        return logits
+
 
 def fit_intercept_fixed_coef(X, coef_, y, output_dim):
     """Optimize the likelihood w.r.t. the intercept for a logistic

--- a/pyuoi/linear_model/logistic.py
+++ b/pyuoi/linear_model/logistic.py
@@ -31,7 +31,7 @@ class UoI_L1Logistic(AbstractUoILinearClassifier, LogisticRegression):
     def __init__(self, n_boots_sel=48, n_boots_est=48, selection_frac=0.9,
                  estimation_frac=0.9, n_C=48, stability_selection=1.,
                  warm_start=False, estimation_score='acc',
-                 copy_X=True, fit_intercept=True, normalize=True,
+                 copy_X=True, fit_intercept=True, standardize=True,
                  random_state=None, max_iter=10000, tol=1e-3,
                  shared_support=True, comm=None):
         super(UoI_L1Logistic, self).__init__(
@@ -44,11 +44,12 @@ class UoI_L1Logistic(AbstractUoILinearClassifier, LogisticRegression):
             random_state=random_state,
             copy_X=copy_X,
             fit_intercept=fit_intercept,
-            normalize=normalize,
+            standardize=standardize,
             shared_support=shared_support,
             comm=comm)
         self.n_C = n_C
         self.Cs = None
+        self.tol = tol
         self.__selection_lm = MaskedCoefLogisticRegression(
             penalty='l1',
             max_iter=max_iter,

--- a/pyuoi/linear_model/logistic.py
+++ b/pyuoi/linear_model/logistic.py
@@ -30,7 +30,7 @@ class UoI_L1Logistic(AbstractUoILinearClassifier, LogisticRegression):
 
     def __init__(self, n_boots_sel=48, n_boots_est=48, selection_frac=0.9,
                  estimation_frac=0.9, n_C=48, stability_selection=1.,
-                 warm_start=False, estimation_score='acc',
+                 warm_start=False, estimation_score='acc', multi_class='auto',
                  copy_X=True, fit_intercept=True, standardize=True,
                  random_state=None, max_iter=10000, tol=1e-3,
                  shared_support=True, comm=None):
@@ -49,34 +49,27 @@ class UoI_L1Logistic(AbstractUoILinearClassifier, LogisticRegression):
             comm=comm)
         self.n_C = n_C
         self.Cs = None
+        self.multi_class = multi_class
         self.tol = tol
-        self.__selection_lm = MaskedCoefLogisticRegression(
+        self.selection_lm = MaskedCoefLogisticRegression(
             penalty='l1',
             max_iter=max_iter,
             warm_start=warm_start,
             random_state=random_state,
-            multi_class='auto',
+            multi_class=multi_class,
             fit_intercept=fit_intercept,
             tol=tol)
         # sklearn cannot do LogisticRegression without penalization, due to the
         # ill-posed nature of the problem. We may want to set C=np.inf for no
         # penalization, but we risk no convergence.
 
-        self.__estimation_lm = MaskedCoefLogisticRegression(
+        self.estimation_lm = MaskedCoefLogisticRegression(
             C=np.inf,
             random_state=random_state,
             multi_class='auto',
             fit_intercept=fit_intercept,
             max_iter=max_iter,
             tol=tol)
-
-    @property
-    def estimation_lm(self):
-        return self.__estimation_lm
-
-    @property
-    def selection_lm(self):
-        return self.__selection_lm
 
     def get_reg_params(self, X, y):
         if self.Cs is None:
@@ -91,7 +84,7 @@ class UoI_L1Logistic(AbstractUoILinearClassifier, LogisticRegression):
 
         This is used in cases where the model has no support selected.
         """
-        return LogisticInterceptFitterNoFeatures(y, self._n_classes)
+        return LogisticInterceptFitterNoFeatures(y, self.output_dim)
 
     def _fit_intercept(self, X, y):
         """"Fit a model with an intercept and fixed coefficients.
@@ -101,24 +94,21 @@ class UoI_L1Logistic(AbstractUoILinearClassifier, LogisticRegression):
         """
         if self.fit_intercept:
             self.intercept_ = fit_intercept_fixed_coef(X, self.coef_, y,
-                                                       self._n_classes)
+                                                       self.output_dim)
         else:
-            n = self._n_classes
-            if self._n_classes == 2:
-                n = 1
-            self.intercept_ = np.zeros(n)
+            self.intercept_ = np.zeros(self.output_dim)
 
 
-def fit_intercept_fixed_coef(X, coef_, y, n_classes):
+def fit_intercept_fixed_coef(X, coef_, y, output_dim):
     """Optimize the likelihood w.r.t. the intercept for a logistic
     model."""
-    if n_classes == 2:
+    if output_dim == 1:
         def f_df(intercept):
             py = sigmoid(X.dot(coef_.T) + intercept)
             dfdb = py.mean() - y.mean()
             return log_loss(y, py), np.atleast_1d(dfdb)
 
-        opt = minimize(f_df, np.atleast_1d(np.zeros(n_classes - 1)),
+        opt = minimize(f_df, np.atleast_1d(np.zeros(1)),
                        method='L-BFGS-B', jac=True)
         return opt.x
     else:
@@ -130,15 +120,15 @@ def fit_intercept_fixed_coef(X, coef_, y, n_classes):
                 if ii == 0:
                     return -pyi[1:]
                 else:
-                    rval = np.eye(n_classes - 1)[ii - 1]
+                    rval = np.eye(output_dim - 1)[ii - 1]
                     rval -= pyi[1:]
                     return rval
 
             dfdb = np.zeros_like(short_intercept)
             for yi, pyi in zip(y, py):
                 dfdb -= dlogpi_dintk(yi, pyi) / y.size
-            return log_loss(y, py, labels=np.arange(n_classes)), dfdb
-        opt = minimize(f_df, np.atleast_1d(np.zeros(n_classes - 1)),
+            return log_loss(y, py, labels=np.arange(output_dim)), dfdb
+        opt = minimize(f_df, np.atleast_1d(np.zeros(output_dim - 1)),
                        method='L-BFGS-B', jac=True)
         intercept = np.concatenate([np.atleast_1d(1.), opt.x])
         return intercept - intercept.max()
@@ -152,19 +142,19 @@ class LogisticInterceptFitterNoFeatures(object):
     y : ndarray
         Class labels.
     """
-    def __init__(self, y, n_classes):
-        self._n_classes = n_classes
+    def __init__(self, y, output_dim):
+        self.output_dim = output_dim
         eps = 1e-10
-        if n_classes == 2:
+        if output_dim == 1:
             p = y.mean(axis=0)
             p = np.minimum(np.maximum(p, eps), 1 - eps)
             self.intercept_ = np.log(p / (1. - p))
         else:
             py = np.equal(y[:, np.newaxis],
-                          np.arange(self._n_classes)[np.newaxis]).mean(axis=0)
+                          np.arange(self.output_dim)[np.newaxis]).mean(axis=0)
             n_included = np.count_nonzero(py)
-            if n_included < self._n_classes:
-                new_mass = eps * (self._n_classes - n_included)
+            if n_included < self.output_dim:
+                new_mass = eps * (self.output_dim - n_included)
                 py *= (1. - new_mass)
                 py[np.equal(py, 0.)] = eps
             intercept = np.log(py)
@@ -172,14 +162,14 @@ class LogisticInterceptFitterNoFeatures(object):
 
     def predict(self, X, mask=None):
         n_samples = X.shape[0]
-        if self._n_classes == 2:
+        if self.output_dim == 1:
             return np.tile(int(self.intercept_ >= 0.), n_samples)
         else:
             return np.tile(int(np.argmax(self.intercept_)), n_samples)
 
     def predict_proba(self, X, mask=None):
         n_samples = X.shape[0]
-        if self._n_classes == 2:
+        if self.output_dim == 1:
             return np.tile(sigmoid(self.intercept_), n_samples)
         else:
             return np.tile(softmax(self.intercept_)[np.newaxis], (n_samples, 1))

--- a/pyuoi/linear_model/poisson.py
+++ b/pyuoi/linear_model/poisson.py
@@ -9,212 +9,6 @@ from sklearn.linear_model.base import LinearModel
 from sklearn.linear_model.base import _preprocess_data
 from sklearn.utils import check_X_y
 
-class UoI_Poisson(AbstractUoILinearRegressor):
-
-    _AbstractUoILinearRegressor__valid_estimation_metrics = \
-        ('log', 'AIC', 'AICc', 'BIC')
-
-    def __init__(self, n_lambdas=48, alphas=np.array([0.5]),
-                 n_boots_sel=48, n_boots_est=48, selection_frac=0.9,
-                 estimation_frac=0.9, stability_selection=1.,
-                 estimation_score='log', warm_start=True, eps=1e-3,
-                 tol=1e-5, copy_X=True, fit_intercept=True,
-                 standardize=True, random_state=None, max_iter=1000,
-                 comm=None):
-        super(UoI_Poisson, self).__init__(
-            n_boots_sel=n_boots_sel,
-            n_boots_est=n_boots_est,
-            selection_frac=selection_frac,
-            estimation_frac=estimation_frac,
-            stability_selection=stability_selection,
-            estimation_score=estimation_score,
-            copy_X=copy_X,
-            fit_intercept=fit_intercept,
-            standardize=standardize,
-            random_state=random_state,
-            comm=comm)
-        self.n_lambdas = n_lambdas
-        self.alphas = alphas
-        self.n_alphas = len(alphas)
-        self.warm_start = warm_start
-        self.eps = eps
-        self.lambdas = None
-        self.__selection_lm = Poisson(
-            fit_intercept=fit_intercept,
-            standardize=standardize,
-            max_iter=max_iter,
-            tol=tol,
-            warm_start=warm_start)
-        # estimation is a Poisson regression with no regularization
-        self.__estimation_lm = Poisson(
-            alpha=0,
-            l1_ratio=0,
-            fit_intercept=fit_intercept,
-            standardize=standardize,
-            max_iter=max_iter,
-            tol=tol,
-            warm_start=False)
-
-    @property
-    def estimation_lm(self):
-        return self.__estimation_lm
-
-    @property
-    def selection_lm(self):
-        return self.__selection_lm
-
-    def fit(self, X, y, stratify=None, verbose=False):
-        """Fit data according to the UoI algorithm.
-
-        Additionaly, perform X-y checks, data preprocessing, and setting
-        intercept.
-
-        Parameters
-        ----------
-        X : ndarray or scipy.sparse matrix, (n_samples, n_features)
-            The design matrix.
-
-        y : ndarray, shape (n_samples,)
-            Response vector. Will be cast to X's dtype if necessary.
-            Currently, this implementation does not handle multiple response
-            variables.
-
-        stratify : array-like or None, default None
-            Ensures groups of samples are alloted to training/test sets
-            proportionally. Labels for each group must be an int greater
-            than zero. Must be of size equal to the number of samples, with
-            further restrictions on the number of groups.
-        """
-        # perform checks
-        X, y = check_X_y(X, y, accept_sparse=['csr', 'csc', 'coo'],
-                         y_numeric=True, multi_output=True)
-        # preprocess data
-        X, y, X_offset, y_offset, X_scale = self.preprocess_data(X, y)
-        super(AbstractUoILinearRegressor, self).fit(X, y, stratify=stratify,
-                                                    verbose=verbose)
-        self.coef_ = self.coef_.squeeze()
-        self._fit_intercept(X, y)
-        return self
-
-    def get_reg_params(self, X, y):
-        """Calculates the regularization parameters (alpha and lambda) to be
-        used for the provided data.
-
-        Note that the Elastic Net penalty is given by
-
-                1 / (2 * n_samples) * ||y - Xb||^2_2
-            + lambda * (alpha * |b|_1 + 0.5 * (1 - alpha) * |b|^2_2)
-
-        where lambda and alpha are regularization parameters.
-
-        Scikit-learn does not use these names. Instead, scitkit-learn
-        denotes alpha by 'l1_ratio' and lambda by 'alpha'.
-
-        Parameters
-        ----------
-        X : array-like, shape (n_samples, n_features)
-            The design matrix.
-
-        y : array-like, shape (n_samples)
-            The response vector.
-
-        Returns
-        -------
-        reg_params : a list of dictionaries
-            A list containing dictionaries with the value of each
-            (lambda, alpha) describing the type of regularization to impose.
-            The keys adhere to scikit-learn's terminology (lambda->alpha,
-            alpha->l1_ratio). This allows easy passing into the ElasticNet
-            object.
-        """
-        if self.lambdas is None:
-            self.lambdas = np.zeros((self.n_alphas, self.n_lambdas))
-            # a set of lambdas are generated for each alpha value (l1_ratio in
-            # sci-kit learn parlance)
-            for alpha_idx, alpha in enumerate(self.alphas):
-                self.lambdas[alpha_idx, :] = np.logspace(
-                    start=np.log10(3),
-                    stop=-3,
-                    num=self.n_lambdas)
-
-        # place the regularization parameters into a list of dictionaries
-        reg_params = list()
-        for alpha_idx, alpha in enumerate(self.alphas):
-            for lamb_idx, lamb in enumerate(self.lambdas[alpha_idx]):
-                # reset the regularization parameter
-                reg_params.append(dict(alpha=lamb, l1_ratio=alpha))
-
-        return reg_params
-
-    def score_predictions(self, metric, fitter, X, y, support):
-        """Score, according to some metric, predictions provided by a model.
-
-        The resulting score will be negated if an information criterion is
-        specified.
-
-        Parameters
-        ----------
-        metric : string
-            The type of score to run on the prediction. Valid options include
-            'r2' (explained variance), 'BIC' (Bayesian information criterion),
-            'AIC' (Akaike information criterion), and 'AICc' (corrected AIC).
-
-        fitter : Poisson object
-            The Poisson object that has been fit to the data with the
-            respective hyperparameters.
-
-        X : nd-array
-            The design matrix.
-
-        y : nd-array
-            The response vector.
-
-        support: array-like
-            The indices of the non-zero features.
-
-        Returns
-        -------
-        score : float
-            The score.
-        """
-        # for Poisson, use predict_mean to calculate the "predicted" values
-        y_pred = fitter.predict_mean(X[:, support])
-        # calculate the log-likelihood
-        ll = utils.log_likelihood_glm(model='poisson', y_true=y, y_pred=y_pred)
-        if metric == 'log':
-            score = ll
-        # information criteria
-        else:
-            n_features = np.count_nonzero(support)
-            if fitter.intercept_ != 0:
-                n_features += 1
-            n_samples = y.size
-            if metric == 'BIC':
-                score = utils.BIC(ll, n_features, n_samples)
-            elif metric == 'AIC':
-                score = utils.AIC(ll, n_features)
-            elif metric == 'AICc':
-                score = utils.AICc(ll, n_features, n_samples)
-            else:
-                raise ValueError(metric + ' is not a valid metric.')
-            # negate the score since lower information criterion is
-            # preferable
-            score = -score
-
-        return score
-
-    def _fit_intercept(self, X, y):
-        """"Fit a model with an intercept and fixed coefficients.
-
-        This is used to re-fit the intercept after the coefficients are
-        estimated.
-        """
-        if self.fit_intercept:
-            mu = np.exp(np.dot(X, self.coef_))
-            self.intercept_ = np.log(np.mean(y)/np.mean(mu))
-        else:
-            self.intercept_ = np.zeros(1)
-
 
 class Poisson(LinearModel):
     def __init__(self, alpha=1.0, l1_ratio=0.5, fit_intercept=True,
@@ -503,6 +297,170 @@ class Poisson(LinearModel):
         This is used in cases where the model has no support selected.
         """
         return PoissonInterceptFitterNoFeatures(y)
+
+
+class UoI_Poisson(AbstractUoILinearRegressor, Poisson):
+
+    _AbstractUoILinearRegressor__valid_estimation_metrics = \
+        ('log', 'AIC', 'AICc', 'BIC')
+
+    def __init__(self, n_lambdas=48, alphas=np.array([0.5]),
+                 n_boots_sel=48, n_boots_est=48, selection_frac=0.9,
+                 estimation_frac=0.9, stability_selection=1.,
+                 estimation_score='log', warm_start=True, eps=1e-3,
+                 tol=1e-5, copy_X=True, fit_intercept=True,
+                 standardize=True, random_state=None, max_iter=1000,
+                 comm=None):
+        super(UoI_Poisson, self).__init__(
+            n_boots_sel=n_boots_sel,
+            n_boots_est=n_boots_est,
+            selection_frac=selection_frac,
+            estimation_frac=estimation_frac,
+            stability_selection=stability_selection,
+            estimation_score=estimation_score,
+            copy_X=copy_X,
+            fit_intercept=fit_intercept,
+            standardize=standardize,
+            random_state=random_state,
+            comm=comm)
+        self.n_lambdas = n_lambdas
+        self.alphas = alphas
+        self.n_alphas = len(alphas)
+        self.warm_start = warm_start
+        self.eps = eps
+        self.lambdas = None
+        self.__selection_lm = Poisson(
+            fit_intercept=fit_intercept,
+            max_iter=max_iter,
+            tol=tol,
+            warm_start=warm_start)
+        # estimation is a Poisson regression with no regularization
+        self.__estimation_lm = Poisson(
+            alpha=0,
+            l1_ratio=0,
+            fit_intercept=fit_intercept,
+            max_iter=max_iter,
+            tol=tol,
+            warm_start=False)
+
+    def get_reg_params(self, X, y):
+        """Calculates the regularization parameters (alpha and lambda) to be
+        used for the provided data.
+
+        Note that the Elastic Net penalty is given by
+
+                1 / (2 * n_samples) * ||y - Xb||^2_2
+            + lambda * (alpha * |b|_1 + 0.5 * (1 - alpha) * |b|^2_2)
+
+        where lambda and alpha are regularization parameters.
+
+        Scikit-learn does not use these names. Instead, scitkit-learn
+        denotes alpha by 'l1_ratio' and lambda by 'alpha'.
+
+        Parameters
+        ----------
+        X : array-like, shape (n_samples, n_features)
+            The design matrix.
+
+        y : array-like, shape (n_samples)
+            The response vector.
+
+        Returns
+        -------
+        reg_params : a list of dictionaries
+            A list containing dictionaries with the value of each
+            (lambda, alpha) describing the type of regularization to impose.
+            The keys adhere to scikit-learn's terminology (lambda->alpha,
+            alpha->l1_ratio). This allows easy passing into the ElasticNet
+            object.
+        """
+        if self.lambdas is None:
+            self.lambdas = np.zeros((self.n_alphas, self.n_lambdas))
+            # a set of lambdas are generated for each alpha value (l1_ratio in
+            # sci-kit learn parlance)
+            for alpha_idx, alpha in enumerate(self.alphas):
+                self.lambdas[alpha_idx, :] = np.logspace(
+                    start=np.log10(3),
+                    stop=-3,
+                    num=self.n_lambdas)
+
+        # place the regularization parameters into a list of dictionaries
+        reg_params = list()
+        for alpha_idx, alpha in enumerate(self.alphas):
+            for lamb_idx, lamb in enumerate(self.lambdas[alpha_idx]):
+                # reset the regularization parameter
+                reg_params.append(dict(alpha=lamb, l1_ratio=alpha))
+
+        return reg_params
+
+    def _score_predictions(self, metric, fitter, X, y, support):
+        """Score, according to some metric, predictions provided by a model.
+
+        The resulting score will be negated if an information criterion is
+        specified.
+
+        Parameters
+        ----------
+        metric : string
+            The type of score to run on the prediction. Valid options include
+            'r2' (explained variance), 'BIC' (Bayesian information criterion),
+            'AIC' (Akaike information criterion), and 'AICc' (corrected AIC).
+
+        fitter : Poisson object
+            The Poisson object that has been fit to the data with the
+            respective hyperparameters.
+
+        X : nd-array
+            The design matrix.
+
+        y : nd-array
+            The response vector.
+
+        support: array-like
+            The indices of the non-zero features.
+
+        Returns
+        -------
+        score : float
+            The score.
+        """
+        # for Poisson, use predict_mean to calculate the "predicted" values
+        y_pred = fitter.predict_mean(X[:, support])
+        # calculate the log-likelihood
+        ll = utils.log_likelihood_glm(model='poisson', y_true=y, y_pred=y_pred)
+        if metric == 'log':
+            score = ll
+        # information criteria
+        else:
+            n_features = np.count_nonzero(support)
+            if fitter.intercept_ != 0:
+                n_features += 1
+            n_samples = y.size
+            if metric == 'BIC':
+                score = utils.BIC(ll, n_features, n_samples)
+            elif metric == 'AIC':
+                score = utils.AIC(ll, n_features)
+            elif metric == 'AICc':
+                score = utils.AICc(ll, n_features, n_samples)
+            else:
+                raise ValueError(metric + ' is not a valid metric.')
+            # negate the score since lower information criterion is
+            # preferable
+            score = -score
+
+        return score
+
+    def _fit_intercept(self, X, y):
+        """"Fit a model with an intercept and fixed coefficients.
+
+        This is used to re-fit the intercept after the coefficients are
+        estimated.
+        """
+        if self.fit_intercept:
+            mu = np.exp(np.dot(X, self.coef_))
+            self.intercept_ = np.log(np.mean(y)/np.mean(mu))
+        else:
+            self.intercept_ = np.zeros(1)
 
 class PoissonInterceptFitterNoFeatures(object):
     def __init__(self, y):

--- a/pyuoi/linear_model/poisson.py
+++ b/pyuoi/linear_model/poisson.py
@@ -19,7 +19,7 @@ class UoI_Poisson(AbstractUoILinearRegressor):
                  estimation_frac=0.9, stability_selection=1.,
                  estimation_score='log', warm_start=True, eps=1e-3,
                  tol=1e-5, copy_X=True, fit_intercept=True,
-                 normalize=True, random_state=None, max_iter=1000,
+                 standardize=True, random_state=None, max_iter=1000,
                  comm=None):
         super(UoI_Poisson, self).__init__(
             n_boots_sel=n_boots_sel,
@@ -30,7 +30,7 @@ class UoI_Poisson(AbstractUoILinearRegressor):
             estimation_score=estimation_score,
             copy_X=copy_X,
             fit_intercept=fit_intercept,
-            normalize=normalize,
+            standardize=standardize,
             random_state=random_state,
             comm=comm)
         self.n_lambdas = n_lambdas
@@ -41,7 +41,7 @@ class UoI_Poisson(AbstractUoILinearRegressor):
         self.lambdas = None
         self.__selection_lm = Poisson(
             fit_intercept=fit_intercept,
-            normalize=normalize,
+            standardize=standardize,
             max_iter=max_iter,
             tol=tol,
             warm_start=warm_start)
@@ -50,7 +50,7 @@ class UoI_Poisson(AbstractUoILinearRegressor):
             alpha=0,
             l1_ratio=0,
             fit_intercept=fit_intercept,
-            normalize=normalize,
+            standardize=standardize,
             max_iter=max_iter,
             tol=tol,
             warm_start=False)
@@ -62,13 +62,6 @@ class UoI_Poisson(AbstractUoILinearRegressor):
     @property
     def selection_lm(self):
         return self.__selection_lm
-
-    def preprocess_data(self, X, y):
-        # ensure that we fit the intercept by hand, but normalize if desired
-        return _preprocess_data(
-            X, y, fit_intercept=False, normalize=self.normalize,
-            copy=self.copy_X
-        )
 
     def fit(self, X, y, stratify=None, verbose=False):
         """Fit data according to the UoI algorithm.
@@ -225,7 +218,7 @@ class UoI_Poisson(AbstractUoILinearRegressor):
 
 class Poisson(LinearModel):
     def __init__(self, alpha=1.0, l1_ratio=0.5, fit_intercept=True,
-                 normalize=False, max_iter=1000, tol=1e-5, warm_start=True):
+                 standardize=False, max_iter=1000, tol=1e-5, warm_start=True):
         """Generalized Linear Model with exponential link function
         (i.e. Poisson) trained with L1/L2 regularizer (i.e. Elastic net
         penalty).
@@ -249,8 +242,8 @@ class Poisson(LinearModel):
         fit_intercept : boolean, default True
             Whether to fit an intercept or not.
 
-        normalize : boolean, optional, default False
-            If True, the regressors X will be normalized before regression by
+        standardize : boolean, optional, default False
+            If True, the regressors X will be standardized before regression by
             subtracting the mean and dividing by the l2-norm.
 
         tol : float, optional
@@ -274,7 +267,7 @@ class Poisson(LinearModel):
         self.alpha = alpha
         self.l1_ratio = l1_ratio
         self.fit_intercept = fit_intercept
-        self.normalize = normalize
+        self.standardize = standardize
         self.max_iter = max_iter
         self.tol = tol
         self.warm_start = warm_start
@@ -311,7 +304,7 @@ class Poisson(LinearModel):
         # we will handle the intercept by hand: only preprocess the design
         # matrix
         X, _, X_offset, _, X_scale = _preprocess_data(
-            X, y, fit_intercept=False, normalize=self.normalize)
+            X, y, fit_intercept=False, standardize=self.standardize)
 
         # all features are initially active
         active_idx = np.arange(self.n_features)

--- a/pyuoi/utils.py
+++ b/pyuoi/utils.py
@@ -90,7 +90,6 @@ def make_classification(n_samples=100, n_features=20, n_informative=2,
             idxs = rng.permutation(n_features)[:n_not_informative]
             w[idxs] = 0.
     w *= w_scale
-    intercept *= w_scale * 2.
 
     log_p = X.dot(w)
     if include_intercept:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 h5py
-scikit-learn
+scikit-learn==0.20.1
 numpy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-h5py
-scikit-learn==0.20.1
 numpy
+h5py
+scikit-learn

--- a/tests/test_elasticnet.py
+++ b/tests/test_elasticnet.py
@@ -82,6 +82,7 @@ def test_uoi_enet_toy():
         fit_intercept=False,
         selection_frac=0.75,
         estimation_frac=0.75,
+        standardize=False
     )
     enet.fit(X, y)
 
@@ -129,10 +130,11 @@ def test_intercept():
     y = np.array([8, 5, 14, 17])
 
     enet = UoI_ElasticNet(
-        fit_intercept=True)
+        fit_intercept=True,
+        standardize=False)
     enet.fit(X, y)
 
-    assert enet.intercept_ == np.mean(y) - np.dot(X.mean(axis=0), enet.coef_)
+    assert enet.intercept_ == (np.mean(y) - np.dot(X.mean(axis=0), enet.coef_))
 
 
 def test_enet_selection_sweep():
@@ -144,15 +146,16 @@ def test_enet_selection_sweep():
         [4, 1, -7],
         [1, 3, 1],
         [4, 3, 12],
-        [8, 11, 2]])
-    beta = np.array([1, 4, 2])
+        [8, 11, 2]], dtype=float)
+    beta = np.array([1, 4, 2], dtype=float)
     y = np.dot(X, beta)
 
     # toy regularization
     reg_param_values = [{'alpha': 1.0}, {'alpha': 2.0}]
-    enet1 = ElasticNet(alpha=1.0, fit_intercept=True)
-    enet2 = ElasticNet(alpha=2.0, fit_intercept=True)
-    enet = UoI_ElasticNet(fit_intercept=True)
+    enet = UoI_ElasticNet(fit_intercept=True, warm_start=False)
+    enet1 = ElasticNet(alpha=1.0, fit_intercept=True, max_iter=enet.max_iter)
+    enet2 = ElasticNet(alpha=2.0, fit_intercept=True, max_iter=enet.max_iter)
+    enet.output_dim = 1
 
     coefs = enet.uoi_selection_sweep(X, y, reg_param_values)
     enet1.fit(X, y)

--- a/tests/test_elasticnet.py
+++ b/tests/test_elasticnet.py
@@ -75,6 +75,8 @@ def test_uoi_enet_toy():
         [8, 11]], dtype=float)
     beta = np.array([1, 4], dtype=float)
     y = np.dot(X, beta)
+    X = np.tile(X, (3, 1))
+    y = np.tile(y, 3)
 
     # choose selection_frac to be slightly smaller to ensure that we get
     # good test sets
@@ -82,7 +84,6 @@ def test_uoi_enet_toy():
         fit_intercept=False,
         selection_frac=0.75,
         estimation_frac=0.75,
-        standardize=False
     )
     enet.fit(X, y)
 
@@ -96,8 +97,8 @@ def test_get_reg_params():
         [-1, 2],
         [0, 1],
         [1, 3],
-        [4, 3]])
-    y = np.array([7, 4, 13, 16])
+        [4, 3]], dtype=float)
+    y = np.array([7, 4, 13, 16], dtype=float)
 
     # calculate regularization parameters manually
     l1_ratio = .5
@@ -114,8 +115,9 @@ def test_get_reg_params():
 
     # check each regularization parameter and key
     for estimate, true in zip(reg_params, alphas):
-        assert estimate.keys() == true.keys()
-        assert_allclose(list(estimate.values()), list(true.values()))
+        assert len(estimate) == len(true)
+        for key, value in estimate.items():
+            assert_allclose(true[key], value)
 
 
 def test_intercept():
@@ -126,12 +128,11 @@ def test_intercept():
         [-1, 2],
         [0, 1],
         [1, 3],
-        [4, 3]])
-    y = np.array([8, 5, 14, 17])
+        [4, 3]], dtype=float)
+    y = np.array([8, 5, 14, 17], dtype=float)
 
     enet = UoI_ElasticNet(
-        fit_intercept=True,
-        standardize=False)
+        fit_intercept=True)
     enet.fit(X, y)
 
     assert enet.intercept_ == (np.mean(y) - np.dot(X.mean(axis=0), enet.coef_))

--- a/tests/test_elasticnet.py
+++ b/tests/test_elasticnet.py
@@ -81,7 +81,7 @@ def test_uoi_enet_toy():
     enet = UoI_ElasticNet(
         fit_intercept=False,
         selection_frac=0.75,
-        estimation_frac=0.75
+        estimation_frac=0.75,
     )
     enet.fit(X, y)
 
@@ -107,7 +107,6 @@ def test_get_reg_params():
     # calculate regularization parameters with UoI_ElasticNet object
     enet = UoI_ElasticNet(
         n_lambdas=2,
-        normalize=False,
         fit_intercept=False,
         eps=0.1)
     reg_params = enet.get_reg_params(X, y)
@@ -130,7 +129,6 @@ def test_intercept():
     y = np.array([8, 5, 14, 17])
 
     enet = UoI_ElasticNet(
-        normalize=False,
         fit_intercept=True)
     enet.fit(X, y)
 
@@ -152,9 +150,9 @@ def test_enet_selection_sweep():
 
     # toy regularization
     reg_param_values = [{'alpha': 1.0}, {'alpha': 2.0}]
-    enet1 = ElasticNet(alpha=1.0, fit_intercept=True, normalize=True)
-    enet2 = ElasticNet(alpha=2.0, fit_intercept=True, normalize=True)
-    enet = UoI_ElasticNet(fit_intercept=True, normalize=True)
+    enet1 = ElasticNet(alpha=1.0, fit_intercept=True)
+    enet2 = ElasticNet(alpha=2.0, fit_intercept=True)
+    enet = UoI_ElasticNet(fit_intercept=True)
 
     coefs = enet.uoi_selection_sweep(X, y, reg_param_values)
     enet1.fit(X, y)

--- a/tests/test_poisson.py
+++ b/tests/test_poisson.py
@@ -164,26 +164,26 @@ def test_score_predictions():
     uoi_fitter = UoI_Poisson()
 
     # test log-likelihood
-    ll = uoi_fitter.score_predictions(
+    ll = uoi_fitter._score_predictions(
         metric='log',
         fitter=fitter,
         X=X, y=y, support=support)
     assert_almost_equal(ll, -2.5)
 
     # test information criteria
-    aic = uoi_fitter.score_predictions(
+    aic = uoi_fitter._score_predictions(
         metric='AIC',
         fitter=fitter,
         X=X, y=y, support=support)
     assert_almost_equal(aic, 2 * ll - 2)
 
-    aicc = uoi_fitter.score_predictions(
+    aicc = uoi_fitter._score_predictions(
         metric='AICc',
         fitter=fitter,
         X=X, y=y, support=support)
     assert_almost_equal(aicc, aic - 2)
 
-    bic = uoi_fitter.score_predictions(
+    bic = uoi_fitter._score_predictions(
         metric='BIC',
         fitter=fitter,
         X=X, y=y, support=support)
@@ -191,7 +191,7 @@ def test_score_predictions():
 
     # test invalid metric
     assert_raises(ValueError,
-                  uoi_fitter.score_predictions,
+                  uoi_fitter._score_predictions,
                   'fake',
                   fitter,
                   X, y, support)

--- a/tests/test_uoi_l1logistic.py
+++ b/tests/test_uoi_l1logistic.py
@@ -15,8 +15,8 @@ def test_fit_intercept_fixed_coef():
     """Test that the intercept in fit correctly for fixed coefficients."""
     X = np.zeros((6, 5))
     coef = np.ones((1, 5))
-    y = np.ones(6)
-    y[:3] = 0.
+    y = np.ones(6, dtype=int)
+    y[:3] = 0
     b = fit_intercept_fixed_coef(X, coef, y, 2)
     assert_allclose(b, 0.)
 
@@ -33,13 +33,13 @@ def test_fit_intercept_no_features():
     X = np.zeros((5, 1))
     y = np.ones(6, dtype=int)
     y[:3] = 0
-    LR = LogisticInterceptFitterNoFeatures(y, 2)
+    LR = LogisticInterceptFitterNoFeatures(y, 1)
     b = LR.intercept_
     assert_allclose(b, 0.)
 
     y = np.ones(7, dtype=int)
     y[:3] = 0
-    LR = LogisticInterceptFitterNoFeatures(y, 2)
+    LR = LogisticInterceptFitterNoFeatures(y, 1)
     yhat = LR.predict(X)
     assert_allclose(yhat, 1)
     py = LR.predict_proba(X)

--- a/tests/test_uoi_l1logistic.py
+++ b/tests/test_uoi_l1logistic.py
@@ -85,6 +85,7 @@ def test_l1logistic_binary():
                                      include_intercept=True)
 
     l1log = UoI_L1Logistic(random_state=10).fit(X, y)
+    l1log = UoI_L1Logistic(random_state=10, fit_intercept=False).fit(X, y)
     l1log.predict_proba(X)
     l1log.predict_log_proba(X)
     y_hat = l1log.predict(X)
@@ -125,6 +126,7 @@ def test_l1logistic_multiclass_not_shared():
                                      shared_support=False,
                                      w_scale=4.)
     l1log = UoI_L1Logistic(shared_support=False).fit(X, y)
+    l1log.predict_log_proba(X)
     y_hat = l1log.predict(X)
     assert_equal(accuracy_score(y, y_hat), l1log.score(X, y))
     assert (np.sign(abs(w)) == np.sign(abs(l1log.coef_))).mean() >= .8

--- a/tests/test_uoi_l1logistic.py
+++ b/tests/test_uoi_l1logistic.py
@@ -85,6 +85,8 @@ def test_l1logistic_binary():
                                      include_intercept=True)
 
     l1log = UoI_L1Logistic(random_state=10).fit(X, y)
+    l1log.predict_proba(X)
+    l1log.predict_log_proba(X)
     y_hat = l1log.predict(X)
     assert_equal(accuracy_score(y, y_hat), l1log.score(X, y))
     assert (np.sign(abs(w)) == np.sign(abs(l1log.coef_))).mean() >= .8
@@ -103,6 +105,8 @@ def test_l1logistic_multiclass():
                                      shared_support=True,
                                      w_scale=4.)
     l1log = UoI_L1Logistic().fit(X, y)
+    l1log.predict_proba(X)
+    l1log.predict_log_proba(X)
     y_hat = l1log.predict(X)
     assert_equal(accuracy_score(y, y_hat), l1log.score(X, y))
     assert (np.sign(abs(w)) == np.sign(abs(l1log.coef_))).mean() >= .8
@@ -157,19 +161,20 @@ def test_masked_logistic():
 
 def test_estimation_score_usage():
     """Test the ability to change the estimation score in UoI L1Logistic"""
-    methods = ('acc', 'log')
-    X, y, w, b = make_classification(n_samples=100,
+    methods = ('acc', 'log', 'BIC', 'AIC', 'AICc')
+    X, y, w, b = make_classification(n_samples=200,
                                      random_state=6,
-                                     n_informative=2,
-                                     n_features=6)
+                                     n_informative=5,
+                                     n_features=10)
     scores = []
     for method in methods:
-        l1log = UoI_L1Logistic(random_state=12, estimation_score=method)
+        l1log = UoI_L1Logistic(random_state=12, estimation_score=method,
+                               tol=1e-2, n_boots_sel=24, n_boots_est=24)
         assert_equal(l1log.estimation_score, method)
         l1log.fit(X, y)
-        score = np.max(l1log.scores_)
-        scores.append(score)
-    assert_equal(len(set(scores)), len(methods))
+        scores.append(l1log.scores_)
+    scores = np.stack(scores)
+    assert_equal(len(np.unique(scores, axis=0)), len(methods))
 
 
 def test_set_random_state():

--- a/tests/test_uoi_lasso.py
+++ b/tests/test_uoi_lasso.py
@@ -80,7 +80,7 @@ def test_uoi_lasso_toy():
     lasso = UoI_Lasso(
         fit_intercept=False,
         selection_frac=0.75,
-        estimation_frac=0.75
+        estimation_frac=0.75,
     )
     lasso.fit(X, y)
 
@@ -104,7 +104,6 @@ def test_get_reg_params():
     # calculate regularization parameters with UoI_Lasso object
     lasso = UoI_Lasso(
         n_lambdas=2,
-        normalize=False,
         fit_intercept=False,
         eps=0.1)
     reg_params = lasso.get_reg_params(X, y)
@@ -127,7 +126,6 @@ def test_intercept():
     y = np.array([8, 5, 14, 17])
 
     lasso = UoI_Lasso(
-        normalize=False,
         fit_intercept=True)
     lasso.fit(X, y)
 
@@ -149,9 +147,9 @@ def test_lasso_selection_sweep():
 
     # toy regularization
     reg_param_values = [{'alpha': 1.0}, {'alpha': 2.0}]
-    lasso1 = Lasso(alpha=1.0, fit_intercept=True, normalize=True)
-    lasso2 = Lasso(alpha=2.0, fit_intercept=True, normalize=True)
-    lasso = UoI_Lasso(fit_intercept=True, normalize=True)
+    lasso1 = Lasso(alpha=1.0, fit_intercept=True)
+    lasso2 = Lasso(alpha=2.0, fit_intercept=True)
+    lasso = UoI_Lasso(fit_intercept=True)
 
     coefs = lasso.uoi_selection_sweep(X, y, reg_param_values)
     lasso1.fit(X, y)

--- a/tests/test_uoi_lasso.py
+++ b/tests/test_uoi_lasso.py
@@ -81,6 +81,7 @@ def test_uoi_lasso_toy():
         fit_intercept=False,
         selection_frac=0.75,
         estimation_frac=0.75,
+        standardize=False
     )
     lasso.fit(X, y)
 
@@ -122,14 +123,16 @@ def test_intercept():
         [-1, 2],
         [0, 1],
         [1, 3],
-        [4, 3]])
-    y = np.array([8, 5, 14, 17])
+        [4, 3]], dtype=float)
+    y = np.array([8, 5, 14, 17], dtype=float)
 
     lasso = UoI_Lasso(
-        fit_intercept=True)
+        fit_intercept=True,
+        standardize=False)
     lasso.fit(X, y)
 
-    assert lasso.intercept_ == np.mean(y) - np.dot(X.mean(axis=0), lasso.coef_)
+    assert lasso.intercept_ == (np.mean(y) -
+                                np.dot(X.mean(axis=0), lasso.coef_))
 
 
 def test_lasso_selection_sweep():
@@ -141,15 +144,16 @@ def test_lasso_selection_sweep():
         [4, 1, -7],
         [1, 3, 1],
         [4, 3, 12],
-        [8, 11, 2]])
-    beta = np.array([1, 4, 2])
+        [8, 11, 2]], dtype=float)
+    beta = np.array([1, 4, 2], dtype=float)
     y = np.dot(X, beta)
 
     # toy regularization
     reg_param_values = [{'alpha': 1.0}, {'alpha': 2.0}]
-    lasso1 = Lasso(alpha=1.0, fit_intercept=True)
-    lasso2 = Lasso(alpha=2.0, fit_intercept=True)
-    lasso = UoI_Lasso(fit_intercept=True)
+    lasso = UoI_Lasso(fit_intercept=True, warm_start=False)
+    lasso1 = Lasso(alpha=1.0, fit_intercept=True, max_iter=lasso.max_iter)
+    lasso2 = Lasso(alpha=2.0, fit_intercept=True, max_iter=lasso.max_iter)
+    lasso.output_dim = 1
 
     coefs = lasso.uoi_selection_sweep(X, y, reg_param_values)
     lasso1.fit(X, y)

--- a/tests/test_uoi_lasso.py
+++ b/tests/test_uoi_lasso.py
@@ -81,7 +81,6 @@ def test_uoi_lasso_toy():
         fit_intercept=False,
         selection_frac=0.75,
         estimation_frac=0.75,
-        standardize=False
     )
     lasso.fit(X, y)
 
@@ -127,8 +126,7 @@ def test_intercept():
     y = np.array([8, 5, 14, 17], dtype=float)
 
     lasso = UoI_Lasso(
-        fit_intercept=True,
-        standardize=False)
+        fit_intercept=True)
     lasso.fit(X, y)
 
     assert lasso.intercept_ == (np.mean(y) -


### PR DESCRIPTION
Closes #88 
Closes #90 
Closes #97 

This PR makes 3 sets of changes.

1) A small bugfix in `linear_model.fit` so that it uses `estimation_frac` correctly.
2) Removes `normalize` parameter which made input unit norm for some models. Now all linear models have the option to standardize the data before fitting and also before prediction.
3) Cleans up the input/output dimensionality checking across models.