### PR TITLE
intercept_ attribute not getting set properly

### DIFF
--- a/pyuoi/linear_model/base.py
+++ b/pyuoi/linear_model/base.py
@@ -632,7 +632,7 @@ class AbstractUoILinearRegressor(
             self.intercept_ = (y.mean(axis=0) -
                                np.dot(X.mean(axis=0), self.coef_.T))
         else:
-            self.intercept = np.zeros(1)
+            self.intercept_ = np.zeros(1)
 
 
 class LinearInterceptFitterNoFeatures(object):


### PR DESCRIPTION
When running on commit ca9039a5394c9ca3b0eda9a717dcd68e669f34cc, I encountered this error:

`_fit_intercept` was setting the `self.intercept_` attribute incorrectly, leading to `self.intercept_` being `None` when rank 0 went to broadcast it

```
Traceback (most recent call last):
  File "sparse-control/PyUoIMiceSamples.py", line 32, in <module>
    clf.fit(X, Y, verbose=True)
  File "/home/ajtritt/projects/uoi/PyUoI/pyuoi/linear_model/base.py", line 439, in fit
    self.comm, root=0)
  File "/home/ajtritt/projects/uoi/PyUoI/pyuoi/mpi_utils.py", line 86, in Bcast_from_root
    dtype = send.dtype
AttributeError: 'NoneType' object has no attribute 'dtype'
```