### PR TITLE
add README for gallery

### DIFF
--- a/docs/gallery/README.rst
+++ b/docs/gallery/README.rst
@@ -1,0 +1,5 @@
+.. _tutorials:
+
+
+Tutorials
+=========


### PR DESCRIPTION
Fix bug discovered by @JesseLivezey :

```
Running Sphinx v2.2.0
loading translations [en]... done
making output directory... done
loading intersphinx inventory from https://docs.python.org/objects.inv...
intersphinx inventory has moved: https://docs.python.org/objects.inv -> https://docs.python.org/3/objects.inv
generating gallery...

Traceback (most recent call last):
  File "/home/docs/checkouts/readthedocs.org/user_builds/pyuoi/envs/latest/lib/python3.7/site-packages/sphinx/cmd/build.py", line 275, in build_main
    args.tags, args.verbosity, args.jobs, args.keep_going)
  File "/home/docs/checkouts/readthedocs.org/user_builds/pyuoi/envs/latest/lib/python3.7/site-packages/sphinx/application.py", line 269, in __init__
    self._init_builder()
  File "/home/docs/checkouts/readthedocs.org/user_builds/pyuoi/envs/latest/lib/python3.7/site-packages/sphinx/application.py", line 330, in _init_builder
    self.events.emit('builder-inited')
  File "/home/docs/checkouts/readthedocs.org/user_builds/pyuoi/envs/latest/lib/python3.7/site-packages/sphinx/events.py", line 103, in emit
    results.append(callback(self.app, *args))
  File "/home/docs/checkouts/readthedocs.org/user_builds/pyuoi/envs/latest/lib/python3.7/site-packages/sphinx_gallery/gen_gallery.py", line 277, in generate_gallery_rst
    examples_dir, gallery_dir, gallery_conf, seen_backrefs)
  File "/home/docs/checkouts/readthedocs.org/user_builds/pyuoi/envs/latest/lib/python3.7/site-packages/sphinx_gallery/gen_rst.py", line 334, in generate_dir_rst
    fname = _get_readme(src_dir, gallery_conf)
  File "/home/docs/checkouts/readthedocs.org/user_builds/pyuoi/envs/latest/lib/python3.7/site-packages/sphinx_gallery/gen_rst.py", line 324, in _get_readme
    "introduce your gallery.".format(dir_, extensions))
FileNotFoundError: Example directory /home/docs/checkouts/readthedocs.org/user_builds/pyuoi/checkouts/latest/docs/source/../gallery does not have a README file with one of the expected file extensions ['.txt', '.rst']. Please write one to introduce your gallery.

Exception occurred:
  File "/home/docs/checkouts/readthedocs.org/user_builds/pyuoi/envs/latest/lib/python3.7/site-packages/sphinx_gallery/gen_rst.py", line 324, in _get_readme
    "introduce your gallery.".format(dir_, extensions))
FileNotFoundError: Example directory /home/docs/checkouts/readthedocs.org/user_builds/pyuoi/checkouts/latest/docs/source/../gallery does not have a README file with one of the expected file extensions ['.txt', '.rst']. Please write one to introduce your gallery.
The full traceback has been saved in /tmp/sphinx-err-k137v9oq.log, if you want to report the issue to the developers.
Please also report this if it was a user error, so that a better error message can be provided next time.
A bug report can be filed in the tracker at <https://github.com/sphinx-doc/sphinx/issues>. Thanks!
```

Looks like I forgot to include the `README` in #159 