### PR TITLE
added pyproject toml to handle numpy and cython build dep

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+# Minimum requirements for the build system to execute.
+requires = ["setuptools", "wheel", "numpy", "cython"]


### PR DESCRIPTION
This allows pip to install numpy and cython before running setup.py which have them as deps.