### PR TITLE
made pycasso optional

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ install:
     - pip install -r requirements-dev.txt
     - pip install codecov
     - pip install mpi4py
+    - pip install pycasso
     - python setup.py build
     - python setup.py develop
     - pip install pytest-cov

--- a/pyuoi/decomposition/base.py
+++ b/pyuoi/decomposition/base.py
@@ -37,6 +37,7 @@ class AbstractDecompositionModel(BaseEstimator, metaclass=_abc.ABCMeta):
         """
         pass
 
+    @_abc.abstractmethod
     def fit_transform(self, X):
         """Transform the data X according to the fitted decomposition.
 
@@ -50,5 +51,4 @@ class AbstractDecompositionModel(BaseEstimator, metaclass=_abc.ABCMeta):
         X_new : array-like, shape (n_samples, n_components)
             Transformed data.
         """
-        self.fit(X)
-        return self.transform(X)
+        pass

--- a/pyuoi/linear_model/lasso.py
+++ b/pyuoi/linear_model/lasso.py
@@ -1,9 +1,13 @@
-import pycasso
 import numpy as np
 
 from sklearn.exceptions import NotFittedError
 from sklearn.linear_model import Lasso, LinearRegression
 from sklearn.linear_model.coordinate_descent import _alpha_grid
+try:
+    import pycasso
+except ImportError:
+    pycasso = None
+
 from .base import AbstractUoILinearRegressor
 
 
@@ -209,6 +213,8 @@ class UoI_Lasso(AbstractUoILinearRegressor, LinearRegression):
                 random_state=random_state,
                 fit_intercept=fit_intercept)
         elif solver == 'pyc':
+            if pycasso is None:
+                raise ModuleNotFoundError('pycasso is not installed.')
             self._selection_lm = PycLasso(
                 fit_intercept=fit_intercept,
                 max_iter=max_iter)

--- a/pyuoi/linear_model/lasso.py
+++ b/pyuoi/linear_model/lasso.py
@@ -214,7 +214,7 @@ class UoI_Lasso(AbstractUoILinearRegressor, LinearRegression):
                 fit_intercept=fit_intercept)
         elif solver == 'pyc':
             if pycasso is None:
-                raise ModuleNotFoundError('pycasso is not installed.')
+                raise ImportError('pycasso is not installed.')
             self._selection_lm = PycLasso(
                 fit_intercept=fit_intercept,
                 max_iter=max_iter)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 numpy
 h5py
 scikit-learn
-pycasso

--- a/setup.py
+++ b/setup.py
@@ -103,7 +103,7 @@ setup(
     # for example:
     # $ pip install -e .[dev,test]
     extras_require={
-        'MPI': ['mpi4py'],
+        'perf': ['mpi4py', 'pycasso'],
         'dev': dev_requirements
     },
 

--- a/tests/test_cur.py
+++ b/tests/test_cur.py
@@ -133,7 +133,7 @@ def test_CUR():
 
     cur = CUR(max_k=max_k)
 
-    cur.fit(X, c=3)
+    cur.fit_transform(X, c=3)
     column_indices = cur.column_indices_
     columns = cur.components_
 

--- a/tests/test_cur.py
+++ b/tests/test_cur.py
@@ -133,7 +133,7 @@ def test_CUR():
 
     cur = CUR(max_k=max_k)
 
-    cur.fit_transform(X, c=3)
+    cur.fit(X, c=3)
     column_indices = cur.column_indices_
     columns = cur.components_
 

--- a/tests/test_uoi_l1logistic.py
+++ b/tests/test_uoi_l1logistic.py
@@ -345,6 +345,32 @@ def test_l1logistic_sparse_input():
     assert set(classes) >= set(y_hat)
 
 
+@pytest.mark.xfail(raises=ValueError)
+def test_l1logistic_sparse_input_no_center():
+    """Test that multiclass L1 Logistic raises an error when asked to center
+    sparse data.
+    """
+    rs = np.random.RandomState(17)
+    X = sprand(10, 10, random_state=rs)
+    classes = ['abc', 'de', 'fgh']
+    y = np.array(classes)[rs.randint(3, size=10)]
+
+    UoI_L1Logistic(fit_intercept=True)
+
+
+
+@pytest.mark.xfail(raises=ValueError)
+def test_l1logistic_bad_est_score():
+    """Test that multiclass L1 Logistic raises an error when given a bad
+    estimation_score value.
+    """
+    X = np.random.randn(20, 5)
+    y = np.ones(20)
+
+    UoI_L1Logistic(estimation_score='z',
+                   n_boots_sel=10, n_boots_est=10).fit(X, y)
+
+
 def test_reg_params():
     """Test whether the upper bound on the regularization parameters correctly
     zero out the coefficients."""

--- a/tests/test_uoi_l1logistic.py
+++ b/tests/test_uoi_l1logistic.py
@@ -355,8 +355,7 @@ def test_l1logistic_sparse_input_no_center():
     classes = ['abc', 'de', 'fgh']
     y = np.array(classes)[rs.randint(3, size=10)]
 
-    UoI_L1Logistic(fit_intercept=True)
-
+    UoI_L1Logistic(fit_intercept=True).fit(X, y)
 
 
 @pytest.mark.xfail(raises=ValueError)

--- a/tests/test_uoi_lasso.py
+++ b/tests/test_uoi_lasso.py
@@ -219,7 +219,7 @@ def test_choice_of_solver():
 
 
 @pytest.mark.skipif(pycasso is not None, reason='pycasso is installed')
-@pytest.mark.xfail(raises=ImporError)
+@pytest.mark.xfail(raises=ImportError)
 def test_pycasso_error():
     """Tests whether an error is raised if pycasso is not installed.
     """
@@ -268,3 +268,15 @@ def test_pyclasso():
     y_pred = pyclasso.predict(X)
     scores = np.array([r2_score(y, y_pred[:, j]) for j in range(100)])
     assert(np.allclose(1, max(scores)))
+
+
+@pytest.mark.xfail(raises=ValueError)
+def test_lass_bad_est_score():
+    """Test that UoI Lasso raises an error when given a bad
+    estimation_score value.
+    """
+    X = np.random.randn(20, 5)
+    y = np.random.randn(20)
+
+    UoI_Lasso(estimation_score='z',
+              n_boots_sel=10, n_boots_est=10).fit(X, y)

--- a/tests/test_uoi_lasso.py
+++ b/tests/test_uoi_lasso.py
@@ -94,6 +94,7 @@ def test_uoi_lasso_toy():
         solver='cd'
     )
     lasso.fit(X, y)
+    lasso.fit(X, y, verbose=True)
 
     assert_allclose(lasso.coef_, beta)
 

--- a/tests/test_uoi_lasso.py
+++ b/tests/test_uoi_lasso.py
@@ -219,7 +219,7 @@ def test_choice_of_solver():
 
 
 @pytest.mark.skipif(pycasso is not None, reason='pycasso is installed')
-@pytest.mark.xfail(raises=ModuleNotFoundError)
+@pytest.mark.xfail(raises=ImporError)
 def test_pycasso_error():
     """Tests whether an error is raised if pycasso is not installed.
     """


### PR DESCRIPTION
Motivation is 1), to remove strict dependence on unmaintained package and 2) make it possible to create a conda package of pyuoi (can't have pip-only deps).