### PR TITLE
Docstring corrections, tol setting in lasso, temp picasso intercept fix

### DIFF
--- a/pyuoi/lbfgs/_lowlevel.pyx
+++ b/pyuoi/lbfgs/_lowlevel.pyx
@@ -406,7 +406,8 @@ cdef class LBFGS(object):
                                                        <void *>x_a).copy()
 
                 return x_array.reshape(x0.shape)
-            elif r in (LBFGSERR_ROUNDING_ERROR, LBFGSERR_MAXIMUMLINESEARCH) :
+            elif r in (LBFGSERR_ROUNDING_ERROR, LBFGSERR_MAXIMUMLINESEARCH,
+                       LBFGSERR_MAXIMUMITERATION) :
                 warnings.warn(_ERROR_MESSAGES[r])
                 x_array = np.PyArray_SimpleNewFromData(1, tshape, np.NPY_DOUBLE,
                                                        <void *>x_a).copy()

--- a/pyuoi/linear_model/logistic.py
+++ b/pyuoi/linear_model/logistic.py
@@ -297,11 +297,10 @@ class MaskedCoefLogisticRegression(LogisticRegression):
         Tolerance for stopping criteria.
     C : float, optional (default=1.0)
         Inverse of regularization strength; must be a positive float.
-        Like in support vector machines, smaller values specify stronger
-        regularization.
+        Smaller values specify stronger regularization.
     fit_intercept : bool, optional (default=True)
-        Specifies if a constant (a.k.a. bias or intercept) should be
-        added to the decision function.
+        Specifies if a bias or intercept should be added to the decision
+        function.
     standardize : bool, default False
         If True, centers the design matrix across samples and rescales them to
         have standard deviation of 1.
@@ -313,7 +312,7 @@ class MaskedCoefLogisticRegression(LogisticRegression):
         as ``n_samples / (n_classes * np.bincount(y))``.
         Note that these weights will be multiplied with sample_weight (passed
         through the fit method) if sample_weight is specified.
-    max_iter : int, optional (default=100)
+    max_iter : int, optional (default=10000)
         Maximum number of iterations taken for the solvers to converge.
     multi_class : str, {'multinomial', 'auto'}, optional (default='auto')
         For 'multinomial' the loss minimised is the multinomial loss fit
@@ -328,9 +327,8 @@ class MaskedCoefLogisticRegression(LogisticRegression):
         initialization, otherwise, just erase the previous solution.
         Useless for liblinear solver.
     """
-    def __init__(self, penalty='l2', tol=1e-3, C=1.,
-                 fit_intercept=True, standardize=False, class_weight=None,
-                 max_iter=10000,
+    def __init__(self, penalty='l2', tol=1e-3, C=1., fit_intercept=True,
+                 standardize=False, class_weight=None, max_iter=10000,
                  multi_class='auto', verbose=0, warm_start=False):
         if multi_class not in ('multinomial', 'auto'):
             raise ValueError("multi_class should be 'multinomial' or " +

--- a/pyuoi/linear_model/logistic.py
+++ b/pyuoi/linear_model/logistic.py
@@ -32,11 +32,6 @@ class UoI_L1Logistic(AbstractUoIGeneralizedLinearRegressor, LogisticRegression):
     n_boots_est : int
         The number of data bootstraps to use in the estimation module.
         Increasing this number will relax selection and decrease variance.
-    n_lambdas : int
-        The number of regularization values to use for selection.
-    alpha : list or ndarray
-        The parameter that trades off L1 versus L2 regularization for a given
-        lambda.
     selection_frac : float
         The fraction of the dataset to use for training in each resampled
         bootstrap, during the selection module. Small values of this parameter
@@ -46,10 +41,8 @@ class UoI_L1Logistic(AbstractUoIGeneralizedLinearRegressor, LogisticRegression):
         bootstrap, during the estimation module. The remaining data is used
         to obtain validation scores. Small values of this parameters imply
         larger "perturbations" to the dataset.
-    estimation_target : string, "train" | "test"
-        Decide whether to assess the estimation_score on the train
-        or test data across each bootstrap. By deafult, a sensible
-        choice is made based on the chosen estimation_score
+    n_C : int
+        The number of regularization values to use for selection.
     stability_selection : int, float, or array-like
         If int, treated as the number of bootstraps that a feature must
         appear in to guarantee placement in selection profile. If float,
@@ -60,11 +53,19 @@ class UoI_L1Logistic(AbstractUoIGeneralizedLinearRegressor, LogisticRegression):
         profile.
     estimation_score : string, "acc" | "log" | "AIC", | "AICc" | "BIC"
         Objective used to choose the best estimates per bootstrap.
+    estimation_target : string, "train" | "test"
+        Decide whether to assess the estimation_score on the train
+        or test data across each bootstrap. By deafult, a sensible
+        choice is made based on the chosen estimation_score
     multi_class : string, "auto" | "multinomial"
         For "multinomial" the loss minimised is the multinomial loss fit across
         the entire probability distribution, even when the data is binary.
         "auto" selects binary if the data is binary, and otherwise selects
         "multinomial".
+    shared_support : bool
+        For models with more than one output (multinomial logistic regression)
+        this determines whether all outputs share the same support or can
+        have independent supports.
     warm_start : bool
         When set to ``True``, reuse the solution of the previous call to fit as
         initialization, otherwise, just erase the previous solution
@@ -77,10 +78,6 @@ class UoI_L1Logistic(AbstractUoIGeneralizedLinearRegressor, LogisticRegression):
     standardize : bool
         If True, the regressors X will be standardized before regression by
         subtracting the mean and dividing by their standard deviations.
-    shared_support : bool
-        For models with more than one output (multinomial logistic regression)
-        this determines whether all outputs share the same support or can
-        have independent supports.
     max_iter : int
         Maximum number of iterations for iterative fitting methods.
     tol : float
@@ -93,6 +90,10 @@ class UoI_L1Logistic(AbstractUoIGeneralizedLinearRegressor, LogisticRegression):
         RandomState instance used by `np.random`.
     comm : MPI communicator
         If passed, the selection and estimation steps are parallelized.
+    logger : Logger
+        The logger to use for messages when ``verbose=True`` in ``fit``.
+        If *None* is passed, a logger that writes to ``sys.stdout`` will be
+        used.
 
     Attributes
     ----------

--- a/pyuoi/linear_model/logistic.py
+++ b/pyuoi/linear_model/logistic.py
@@ -73,8 +73,7 @@ class UoI_L1Logistic(AbstractUoIGeneralizedLinearRegressor, LogisticRegression):
         Length of the L1 path. eps=1e-5 means that alpha_min / alpha_max = 1e-5
     fit_intercept : bool
         Whether to calculate the intercept for this model. If set to False, no
-        intercept will be used in calculations (e.g. data is expected to be
-        already centered).
+        intercept will be used in calculations.
     standardize : bool
         If True, the regressors X will be standardized before regression by
         subtracting the mean and dividing by their standard deviations.

--- a/pyuoi/linear_model/poisson.py
+++ b/pyuoi/linear_model/poisson.py
@@ -445,6 +445,10 @@ class UoI_Poisson(AbstractUoIGeneralizedLinearRegressor, Poisson):
         RandomState instance used by ``np.random``.
     comm : MPI communicator
         If passed, the selection and estimation steps are parallelized.
+    logger : Logger
+        The logger to use for messages when ``verbose=True`` in ``fit``.
+        If *None* is passed, a logger that writes to ``sys.stdout`` will be
+        used.
 
     Attributes
     ----------

--- a/pyuoi/linear_model/poisson.py
+++ b/pyuoi/linear_model/poisson.py
@@ -430,8 +430,7 @@ class UoI_Poisson(AbstractUoIGeneralizedLinearRegressor, Poisson):
         If ``True``, X will be copied; else, it may be overwritten.
     fit_intercept : boolean
         Whether to calculate the intercept for this model. If set to ``False``,
-        no intercept will be used in calculations (e.g. data is expected to be
-        already centered).
+        no intercept will be used in calculations.
     standardize : bool
         If True, the regressors X will be standardized before regression by
         subtracting the mean and dividing by their standard deviations.

--- a/pyuoi/mpi_utils.py
+++ b/pyuoi/mpi_utils.py
@@ -16,6 +16,17 @@ except ImportError:
 
 def check_valid_ndarray(X):
     """Checks whether X is a ndarray and returns a contiguous version.
+
+    Parameters
+    ----------
+    X : ndarray, `None`, or other
+        Variable to check
+
+    Returns
+    -------
+    X : ndarray or `None`
+        If X is an ndarray, returns a contiguous potential copy. If X is `None`
+        returns `None`. If X is anything else, raises a `ValueError`
     """
     if X is None:
         return X

--- a/tests/test_lbfgs.py
+++ b/tests/test_lbfgs.py
@@ -101,7 +101,7 @@ def test_class_interface():
     assert_array_equal(opt.minimize(f, 1e6), [0])
 
     opt.max_iterations = 1
-    with pytest.raises(LBFGSError):
+    with pytest.warns(UserWarning):
         opt.minimize(f, 1e7)
 
 


### PR DESCRIPTION
PR does a few things

Closes #197

Currently picasso always fits an intercept for lasso. Now, if `fit_intercept=False` with picasso, an error is raised.
Changes to picasso can be reverted after this issue is resolved
https://github.com/jasonge27/picasso/issues/25

This also converts an error with ow-lbfgs when max_iter is reached into a warning, more similar to scipy. This allows max_iter to stop early and still return a value.

Some docs fixes/improvements.