### PR TITLE
fix "module not found" error after install from source

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -86,7 +86,8 @@ setup(
     # You can just specify the packages manually here if your project is
     # simple. Or you can use find_packages().
     package_dir={'': 'src'},
-    packages=find_packages(),
+    packages=find_packages() + 
+        find_packages(where="./src"),
     package_data={'pyuoi': ['data/*.h5']},
 
     # Alternatively, if you want to distribute just a my_module.py, uncomment

--- a/setup.py
+++ b/setup.py
@@ -87,7 +87,7 @@ setup(
     # simple. Or you can use find_packages().
     package_dir={'': 'src'},
     packages=find_packages() + 
-        find_packages(where="./src"),
+        find_packages(where="src"),
     package_data={'pyuoi': ['data/*.h5']},
 
     # Alternatively, if you want to distribute just a my_module.py, uncomment


### PR DESCRIPTION
When installed from source, `from pyuoi.linear_model import UoI_Lasso` fails with a `module not found` error. 

Specifying where to look for submodules in setup.py with another call to `find_packages()` fixes this. 